### PR TITLE
Move LB config to a service_config module to avoid circulr deps

### DIFF
--- a/grpc/src/client/load_balancing/child_manager/mod.rs
+++ b/grpc/src/client/load_balancing/child_manager/mod.rs
@@ -26,9 +26,10 @@
 use std::{collections::HashMap, error::Error, hash::Hash, mem, sync::Arc};
 
 use crate::client::load_balancing::{
-    ChannelController, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, WorkScheduler,
+    ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, WorkScheduler,
 };
 use crate::client::name_resolution::{Address, ResolverUpdate};
+use crate::client::service_config::LbConfig;
 
 use super::{Subchannel, SubchannelState};
 

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -44,6 +44,7 @@ pub mod child_manager;
 pub mod pick_first;
 
 mod registry;
+use super::service_config::LbConfig;
 pub use registry::{LbPolicyRegistry, GLOBAL_LB_REGISTRY};
 
 /// A collection of data configured on the channel that is constructing this
@@ -184,29 +185,6 @@ impl Display for SubchannelState {
                 .map(|e| e.to_string())
                 .unwrap_or_default()
         )
-    }
-}
-
-/// A convenience wrapper for an LB policy's configuration object.
-#[derive(Debug)]
-pub struct LbConfig {
-    config: Arc<dyn Any + Send + Sync>,
-}
-
-impl LbConfig {
-    /// Create a new LbConfig wrapper containing the provided config.
-    pub fn new<T: 'static + Send + Sync>(config: T) -> Self {
-        LbConfig {
-            config: Arc::new(config),
-        }
-    }
-
-    /// Convenience method to extract the LB policy's configuration object.
-    fn convert_to<T: 'static + Send + Sync>(&self) -> Result<Arc<T>, Box<dyn Error + Send + Sync>> {
-        match self.config.clone().downcast::<T>() {
-            Ok(c) => Ok(c),
-            Err(e) => Err("failed to downcast to config type".into()),
-        }
     }
 }
 

--- a/grpc/src/client/load_balancing/pick_first/mod.rs
+++ b/grpc/src/client/load_balancing/pick_first/mod.rs
@@ -15,14 +15,15 @@ use crate::{
     client::{
         load_balancing::{ErroringPicker, LbState, QueuingPicker},
         name_resolution::{Address, Endpoint, ResolverData, ResolverUpdate},
+        service_config::LbConfig,
         subchannel, ConnectivityState,
     },
     service::{Request, Response, Service},
 };
 
 use super::{
-    ChannelController, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions, ParsedJsonLbConfig,
-    Pick, PickResult, Picker, Subchannel, SubchannelImpl, SubchannelState, WorkScheduler,
+    ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, ParsedJsonLbConfig, Pick,
+    PickResult, Picker, Subchannel, SubchannelImpl, SubchannelState, WorkScheduler,
 };
 
 use serde::{Deserialize, Serialize};

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -15,8 +15,34 @@
  * limitations under the License.
  *
  */
+use std::{any::Any, error::Error, sync::Arc};
 
 /// An in-memory representation of a service config, usually provided to gRPC as
 /// a JSON object.
 #[derive(Debug, Default, Clone)]
 pub struct ServiceConfig;
+
+/// A convenience wrapper for an LB policy's configuration object.
+#[derive(Debug)]
+pub struct LbConfig {
+    config: Arc<dyn Any + Send + Sync>,
+}
+
+impl LbConfig {
+    /// Create a new LbConfig wrapper containing the provided config.
+    pub fn new<T: 'static + Send + Sync>(config: T) -> Self {
+        LbConfig {
+            config: Arc::new(config),
+        }
+    }
+
+    /// Convenience method to extract the LB policy's configuration object.
+    pub fn convert_to<T: 'static + Send + Sync>(
+        &self,
+    ) -> Result<Arc<T>, Box<dyn Error + Send + Sync>> {
+        match self.config.clone().downcast::<T>() {
+            Ok(c) => Ok(c),
+            Err(e) => Err("failed to downcast to config type".into()),
+        }
+    }
+}


### PR DESCRIPTION
LB policies will depend on the resolver module for ResolverState, Address, Endpoints etc. Having the LBConfig in the LB module will require the resolver module to depend on the LB module for getting the parsed service config. This PR moves the LbConfig struct to the service_config module that resolver, LB and channel can depend on.