### PR TITLE
Add Graceful Switch First Draft

### DIFF
--- a/Cargo.toml
+++ b/Cargo.toml
@@ -28,12 +28,12 @@ members = [
   "tests/use_arc_self",
   "tests/default_stubs",
   "tests/deprecated_methods",
-  "tests/skip_debug",
+  "tests/skip_debug", "routeguide",
 ]
 resolver = "2"
 
 [workspace.package]
-rust-version = "1.75"
+rust-version = "1.85"
 
 [workspace.lints.rust]
 missing_debug_implementations = "warn"

--- a/grpc/examples/inmemory.rs
+++ b/grpc/examples/inmemory.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 
 use futures_util::stream::StreamExt;
 use grpc::client::load_balancing::pick_first;
+use grpc::client::load_balancing::round_robin;
+
 use grpc::client::transport;
 use grpc::service::{Message, Request, Response, Service};
 use grpc::{client::ChannelOptions, inmemory};
@@ -38,7 +40,7 @@ impl Service for Handler {
 #[tokio::main]
 async fn main() {
     inmemory::reg();
-    pick_first::reg();
+    round_robin::reg();
 
     // Spawn the server.
     let lis = inmemory::Listener::new();

--- a/grpc/examples/multiaddr.rs
+++ b/grpc/examples/multiaddr.rs
@@ -2,6 +2,8 @@ use std::any::Any;
 
 use futures_util::StreamExt;
 use grpc::client::load_balancing::pick_first;
+use grpc::client::load_balancing::round_robin;
+
 use grpc::client::transport;
 use grpc::service::{Message, Request, Response, Service};
 use grpc::{client::ChannelOptions, inmemory};

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -19,7 +19,7 @@ use serde_json::json;
 use tonic::async_trait;
 use url::Url; // NOTE: http::Uri requires non-empty authority portion of URI
 
-use crate::credentials::Credentials;
+use crate::{client::load_balancing::round_robin, credentials::Credentials};
 use crate::rt;
 use crate::service::{Request, Response, Service};
 use crate::{attributes::Attributes, rt::tokio::TokioRuntime};

--- a/grpc/src/client/channel.rs
+++ b/grpc/src/client/channel.rs
@@ -275,9 +275,12 @@ impl ActiveChannel {
             runtime: Arc::new(TokioRuntime {}),
         };
         let resolver = rb.build(&target, resolver_opts);
-
+        //spawn a task and run 
         let jh = runtime.spawn(Box::pin(async move {
             let mut resolver = resolver;
+            //reading from channel until receive returns 
+            //for every w, it sees if it is a closure or scheduleresolver
+            //whatever it queues out of the channel, it runs that work
             while let Some(w) = rx.recv().await {
                 match w {
                     WorkQueueItem::Closure(func) => func(&mut channel_controller),

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -28,13 +28,14 @@ use std::sync::Mutex;
 use std::{collections::HashMap, error::Error, hash::Hash, mem, sync::Arc};
 
 use crate::client::load_balancing::{
-    ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, WeakSubchannel,
-    WorkScheduler,
+    ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+    LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+    Subchannel, SubchannelState, WeakSubchannel, WorkScheduler, GLOBAL_LB_REGISTRY, ConnectivityState,
 };
 use crate::client::name_resolution::{Address, ResolverUpdate};
-use crate::client::service_config::LbConfig;
+use crate::service::{Message, Request, Response, Service};
 
-use super::{Subchannel, SubchannelState};
+use tonic::{metadata::MetadataMap, Status};
 
 use tokio::sync::{mpsc, watch, Notify};
 use tokio::task::{AbortHandle, JoinHandle};
@@ -47,7 +48,12 @@ pub struct ChildManager<T> {
     updated: bool, // true iff a child has updated its state since the last call to has_updated.
     work_requests: Arc<Mutex<HashSet<Arc<T>>>>,
     work_scheduler: Arc<dyn WorkScheduler>,
+    sent_connecting_state: bool,
+    aggregated_state: ConnectivityState,
+    
 }
+
+use std::{sync::{atomic::{AtomicUsize, Ordering}}};
 
 pub trait ChildIdentifier: PartialEq + Hash + Eq + Send + Sync + 'static {}
 
@@ -90,6 +96,8 @@ impl<T: ChildIdentifier> ChildManager<T> {
             updated: false,
             work_requests: Arc::default(),
             work_scheduler,
+            sent_connecting_state: false,
+            aggregated_state: ConnectivityState::Idle,
         }
     }
 
@@ -104,6 +112,8 @@ impl<T: ChildIdentifier> ChildManager<T> {
         mem::take(&mut self.updated)
     }
 
+
+
     // Called to update all accounting in the ChildManager from operations
     // performed by a child policy on the WrappedController that was created for
     // it.
@@ -113,16 +123,18 @@ impl<T: ChildIdentifier> ChildManager<T> {
     // which way is better.
     fn resolve_child_controller(
         &mut self,
-        channel_controller: WrappedController,
+        is_updating_subchannel: bool,
+        channel_controller: &mut WrappedController,
+        
         child_id: Arc<T>,
     ) {
         // Add all created subchannels into the subchannel_child_map.
-        for csc in channel_controller.created_subchannels {
+        for csc in channel_controller.created_subchannels.clone() {
             self.subchannels
                 .insert(WeakSubchannel::new(csc), child_id.clone());
         }
         // Update the tracked state if the child produced an update.
-        if let Some(state) = channel_controller.picker_update {
+        if let Some(state) = channel_controller.picker_update.clone() {
             self.children.get_mut(&child_id.clone()).unwrap().state = state;
             self.updated = true;
         };
@@ -137,6 +149,148 @@ impl<T: ChildIdentifier> ChildManager<T> {
             }
             true
         });
+        self.aggregate_states(channel_controller);
+
+    }
+
+    fn aggregate_states (& mut self, channel_controller: &mut WrappedController,) {
+        
+        println!("Current connectivity state: {}", self.aggregated_state);
+        let current_connectivity_state = self.aggregated_state.clone();
+        let child_states_vec: Vec<_> = self.child_states().collect();
+
+
+        let mut transient_failure_picker = TransientFailurePickers::new("error string I guess".to_string());
+
+        let mut connecting_pickers = ConnectingPickers::new();
+
+        let mut ready_pickers = ReadyPickers::new();
+
+        let mut has_idle = false;
+        // if current_connectivity_state == ConnectivityState::TransientFailure
+        //     && !ready_pickers.has_any()
+        // {
+        //     // Stay in TF, do not send a Connecting picker.
+        //     return;
+        // }
+        for (child, state) in &child_states_vec {
+            match state.connectivity_state {
+                ConnectivityState::Idle => {
+                    connecting_pickers.add_picker(state.picker.clone());
+                    has_idle = true;
+                    // connecting_pickers.add_picker(state.picker.clone());
+                }
+                ConnectivityState::Connecting  => {
+                    connecting_pickers.add_picker(state.picker.clone());
+                }
+                ConnectivityState::Ready => {
+                    ready_pickers.add_picker(state.picker.clone());
+                }
+                ConnectivityState::TransientFailure =>{
+                    transient_failure_picker.add_picker(state.picker.clone());
+                }
+                
+               
+            }
+        }
+
+
+        let has_ready = ready_pickers.has_any();
+        let has_connecting = connecting_pickers.pickers.len() >= 1;
+        // let has_idle = idle_picker.pickers.len() >= 1;
+        let has_transient_failure = transient_failure_picker.pickers.len() >= 1;
+        let all_transient_failure = has_transient_failure
+            && !has_ready
+            && !has_connecting;
+            // && !has_idle;
+
+        // Decide the new aggregate state
+        let new_state = if has_ready {
+            ConnectivityState::Ready
+        }  else if has_connecting {
+            ConnectivityState::Connecting
+        } else  {
+            ConnectivityState::TransientFailure
+        };
+        self.aggregated_state = new_state;
+        println!("new state is {}", new_state);
+
+        // Latch: If we're in TF and new state is not Ready, stay in TF and do nothing
+        
+
+        // Now update state and send picker as appropriate
+        match new_state {
+            ConnectivityState::Ready => {
+                if current_connectivity_state != ConnectivityState::Ready{
+                    println!("sending ready picker update");
+                    self.aggregated_state = ConnectivityState::Ready;
+                    let picker = Arc::new(ready_pickers);
+                    channel_controller.update_picker(LbState {
+                        connectivity_state: ConnectivityState::Ready,
+                        picker,
+                    });
+                    self.sent_connecting_state = false;
+                }
+            }
+            ConnectivityState::Connecting => {
+                if self.aggregated_state == ConnectivityState::TransientFailure
+                    && new_state != ConnectivityState::Ready
+                {
+                    return;
+                }
+                if !self.sent_connecting_state {
+                    println!("sending connecting picker update");
+                    self.aggregated_state = ConnectivityState::Connecting;
+                    let picker = Arc::new(QueuingPicker {});
+                    self.move_to_connecting(has_idle, channel_controller, picker);
+                }
+                // Don't send another Connecting picker if already sent
+            }
+            ConnectivityState::Idle => {
+                if !self.sent_connecting_state {
+                    println!("sending connecting picker update");
+                    self.aggregated_state = ConnectivityState::Connecting;
+                    let picker = Arc::new(QueuingPicker {});
+                    self.move_to_connecting(has_idle, channel_controller, picker);
+                }
+                // Don't send another Connecting picker if already sent
+            }
+            ConnectivityState::TransientFailure => {
+                if current_connectivity_state != ConnectivityState::TransientFailure{
+                    self.aggregated_state = ConnectivityState::TransientFailure;
+                    let picker = Arc::new(transient_failure_picker);
+                    self.move_to_transient_failure(channel_controller, picker);
+                }
+            }
+   
+        }
+
+    }
+}
+
+impl<T: ChildIdentifier> ChildManager<T> {
+    fn move_to_transient_failure(&mut self, channel_controller: &mut WrappedController, picker: Arc<dyn Picker>) {
+        channel_controller.update_picker(LbState {
+                connectivity_state: ConnectivityState::TransientFailure,
+               picker: picker,
+            });
+        println!("requesting resolution");
+        // channel_controller.request_resolution();
+        self.sent_connecting_state = false;
+    }
+
+
+
+    fn move_to_connecting(&mut self, is_idle: bool, channel_controller: &mut WrappedController, picker: Arc<dyn Picker>) {
+        channel_controller.update_picker(LbState {
+            connectivity_state: ConnectivityState::Connecting,
+            picker: picker,
+        });
+        self.sent_connecting_state = true;
+        if is_idle {
+            println!("requesting resolution");
+            channel_controller.request_resolution();
+        }
     }
 }
 
@@ -148,6 +302,15 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
         channel_controller: &mut dyn ChannelController,
     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
         // First determine if the incoming update is valid.
+        let mut channel_controller = WrappedController::new(channel_controller);
+        if let Err(error) = &resolver_update.endpoints {
+        // Move to TransientFailure with the resolver error
+            let picker = Arc::new(TransientFailurePickers::new(error.to_string()));
+            
+            let err = "error".to_string();
+            self.move_to_transient_failure(&mut channel_controller, picker);
+            return Ok(());
+        }
         let child_updates = self.sharder.shard_update(resolver_update)?;
 
         // Remove children that are no longer active.
@@ -177,13 +340,13 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
                     self.children.get_mut(&child_id).unwrap().policy.as_mut()
                 }
             };
-            let mut channel_controller = WrappedController::new(channel_controller);
+            
             let _ = child_policy.resolver_update(
                 update.child_update.clone(),
                 config,
                 &mut channel_controller,
             );
-            self.resolve_child_controller(channel_controller, child_id.clone());
+            self.resolve_child_controller(false, &mut channel_controller, child_id.clone());
         }
 
         // Keep only the subchannels associated with currently active children.
@@ -211,7 +374,7 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
         let mut channel_controller = WrappedController::new(channel_controller);
         // Call the proper child.
         policy.subchannel_update(subchannel, state, &mut channel_controller);
-        self.resolve_child_controller(channel_controller, child_id.clone());
+        self.resolve_child_controller(true, &mut channel_controller, child_id.clone());
     }
 
     fn work(&mut self, channel_controller: &mut dyn ChannelController) {
@@ -223,7 +386,7 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
             if let Some(child) = self.children.get_mut(&child_id) {
                 let mut channel_controller = WrappedController::new(channel_controller);
                 child.policy.work(&mut channel_controller);
-                self.resolve_child_controller(channel_controller, child_id.clone());
+                self.resolve_child_controller(false, &mut channel_controller, child_id.clone());
             }
         }
     }
@@ -262,8 +425,9 @@ impl ChannelController for WrappedController<'_> {
     }
 
     fn update_picker(&mut self, update: LbState) {
-        self.picker_update = Some(update);
-    }
+            self.picker_update = Some(update.clone());
+            self.channel_controller.update_picker(update);
+        }
 
     fn request_resolution(&mut self) {
         self.channel_controller.request_resolution();
@@ -294,5 +458,117 @@ impl<T: ChildIdentifier> WorkScheduler for ChildScheduler<T> {
     fn schedule_work(&self) {
         (*self.work_requests.lock().unwrap()).insert(self.child_identifier.clone());
         self.work_scheduler.schedule_work();
+    }
+}
+
+struct ReadyPickers {
+    pickers: Vec<Arc<dyn Picker>>,
+    next: AtomicUsize,
+}
+
+
+
+impl ReadyPickers {
+    pub fn new() -> Self {
+        Self {
+            pickers: vec![],
+            next: AtomicUsize::new(0),
+        }
+    }
+
+    fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+        self.pickers.push(picker);
+    }
+
+    pub fn has_any(&self) -> bool {
+        !self.pickers.is_empty()
+    }
+}
+
+impl Picker for ReadyPickers {
+    fn pick(&self, request: &Request) -> PickResult {
+        let len = self.pickers.len();
+        if len == 0 {
+            return PickResult::Queue;
+        }
+        let idx = self.next.fetch_add(1, Ordering::Relaxed) % len;
+        self.pickers[idx].pick(request)
+    }
+
+    
+}
+struct ConnectingPickers {
+    pickers: Vec<Arc<dyn Picker>>,
+    // next: AtomicUsize,
+}
+
+impl Picker for ConnectingPickers {
+    fn pick(&self, request: &Request) -> PickResult {
+        
+        return PickResult::Queue;
+        
+    }
+}
+
+impl ConnectingPickers {
+    pub fn new() -> Self {
+        Self {
+            pickers: vec![],
+        }
+    }
+
+    fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+        self.pickers.push(picker);
+    }
+}
+
+struct TransientFailurePickers {
+    pickers: Vec<Arc<dyn Picker>>,
+    error: String,    
+
+}
+
+impl Picker for TransientFailurePickers {
+    fn pick(&self, request: &Request) -> PickResult {
+        
+        return PickResult::Fail(Status::unavailable(self.error.clone()))
+        
+    }
+}
+
+impl TransientFailurePickers {
+    pub fn new(error: String) -> Self {
+        Self {
+            pickers: vec![],
+            error,
+        }
+    }
+
+    fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+        self.pickers.push(picker);
+    }
+}
+struct IdlePickers {
+    pickers: Vec<Arc<dyn Picker>>,
+    // next: AtomicUsize,
+}
+
+impl Picker for IdlePickers {
+    fn pick(&self, request: &Request) -> PickResult {
+        
+        return PickResult::Queue;
+        
+    }
+}
+
+impl IdlePickers {
+    pub fn new() -> Self {
+        Self {
+            pickers: vec![],
+        }
+    }
+
+    fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+        self.pickers.push(picker);
     }
 }

--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -1,3 +1,630 @@
+// /*
+//  *
+//  * Copyright 2025 gRPC authors.
+//  *
+//  * Licensed under the Apache License, Version 2.0 (the "License");
+//  * you may not use this file except in compliance with the License.
+//  * You may obtain a copy of the License at
+//  *
+//  *     http://www.apache.org/licenses/LICENSE-2.0
+//  *
+//  * Unless required by applicable law or agreed to in writing, software
+//  * distributed under the License is distributed on an "AS IS" BASIS,
+//  * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+//  * See the License for the specific language governing permissions and
+//  * limitations under the License.
+//  *
+//  */
+
+// //! A utility which helps parent LB policies manage multiple children for the
+// //! purposes of forwarding channel updates.
+
+// // TODO: This is mainly provided as a fairly complex example of the current LB
+// // policy in use.  Complete tests must be written before it can be used in
+// // production.  Also, support for the work scheduler is missing.
+
+// use std::collections::HashSet;
+// use std::fmt::Display;
+// use std::sync::Mutex;
+// use std::{collections::HashMap, error::Error, hash::Hash, mem, sync::Arc};
+
+// use crate::client::load_balancing::{
+//     ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+//     LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+//     Subchannel, SubchannelState, WeakSubchannel, WorkScheduler, GLOBAL_LB_REGISTRY, ConnectivityState,
+// };
+// use crate::client::name_resolution::{Address, ResolverUpdate};
+// use crate::service::{Message, Request, Response, Service};
+
+// use tonic::{metadata::MetadataMap, Status};
+
+// use tokio::sync::{mpsc, watch, Notify};
+// use tokio::task::{AbortHandle, JoinHandle};
+
+// // An LbPolicy implementation that manages multiple children.
+// pub struct ChildManager<T> {
+//     subchannels: HashMap<WeakSubchannel, Arc<T>>,
+//     children: HashMap<Arc<T>, Child>,
+//     sharder: Box<dyn ResolverUpdateSharder<T>>,
+//     updated: bool, // true iff a child has updated its state since the last call to has_updated.
+//     work_requests: Arc<Mutex<HashSet<Arc<T>>>>,
+//     work_scheduler: Arc<dyn WorkScheduler>,
+//     sent_connecting_state: bool,
+//     aggregated_state: ConnectivityState,
+//     last_ready_pickers: Vec<Arc<dyn Picker>>,
+    
+// }
+
+// use std::{sync::{atomic::{AtomicUsize, Ordering}}};
+
+// pub trait ChildIdentifier: PartialEq + Hash + Eq + Send + Sync + Display + 'static {}
+
+// #[cfg(test)]
+// mod test;
+// struct Child {
+//     policy: Box<dyn LbPolicy>,
+//     state: LbState,
+// }
+
+// /// A collection of data sent to a child of the ChildManager.
+// pub struct ChildUpdate {
+//     /// The builder the ChildManager should use to create this child if it does
+//     /// not exist.
+//     pub child_policy_builder: Arc<dyn LbPolicyBuilder>,
+//     /// The relevant ResolverUpdate to send to this child.
+//     pub child_update: ResolverUpdate,
+// }
+
+// pub trait ResolverUpdateSharder<T: ChildIdentifier>: Send {
+//     /// Performs the operation of sharding an aggregate ResolverUpdate into one
+//     /// or more ChildUpdates.  Called automatically by the ChildManager when its
+//     /// resolver_update method is called.  The key in the returned map is the
+//     /// identifier the ChildManager should use for this child.
+//     fn shard_update(
+//         &self,
+//         resolver_update: ResolverUpdate,
+//     ) -> Result<HashMap<T, ChildUpdate>, Box<dyn Error + Send + Sync>>;
+// }
+
+// impl<T: ChildIdentifier> ChildManager<T> {
+//     /// Creates a new ChildManager LB policy.  shard_update is called whenever a
+//     /// resolver_update operation occurs.
+//     pub fn new(
+//         work_scheduler: Arc<dyn WorkScheduler>,
+//         sharder: Box<dyn ResolverUpdateSharder<T>>,
+//     ) -> Self {
+//         ChildManager {
+//             subchannels: HashMap::default(),
+//             children: HashMap::default(),
+//             sharder,
+//             updated: false,
+//             work_requests: Arc::default(),
+//             work_scheduler,
+//             sent_connecting_state: false,
+//             aggregated_state: ConnectivityState::Idle,
+//             last_ready_pickers: Vec::new(),
+//         }
+//     }
+
+//     /// Returns data for all current children.
+//     pub fn child_states(&mut self) -> impl Iterator<Item = (&T, &LbState)> {
+//         self.children
+//             .iter()
+//             .map(|(id, child)| (id.as_ref(), &child.state))
+//     }
+
+//     pub fn has_updated(&mut self) -> bool {
+//         mem::take(&mut self.updated)
+//     }
+
+
+
+//     // Called to update all accounting in the ChildManager from operations
+//     // performed by a child policy on the WrappedController that was created for
+//     // it.
+//     //
+//     // TODO: this post-processing step can be eliminated by capturing the right
+//     // state inside the WrappedController, however it is fairly complex.  Decide
+//     // which way is better.
+//     fn resolve_child_controller(
+//         &mut self,
+//         channel_controller: &mut WrappedController,        
+//         child_id: Arc<T>,
+//     ) {
+//         // Add all created subchannels into the subchannel_child_map.
+//         for csc in channel_controller.created_subchannels.clone() {
+//             let key = WeakSubchannel::new(csc.clone());
+//             if !self.subchannels.contains_key(&key) {
+//                 println!("inserting subchannel {} into child_id {}", csc, child_id);
+//                 self.subchannels.insert(key, child_id.clone());
+//             }
+           
+//         }
+
+
+
+//         // Update the tracked state if the child produced an update.
+//         if let Some(state) = channel_controller.picker_update.clone() {
+//             self.children.get_mut(&child_id.clone()).unwrap().state = state;
+//             self.updated = true;
+//         };
+//         // Prune subchannels created by this child that are no longer
+//         // referenced.
+//         self.subchannels.retain(|sc, cid| {
+//             if cid != &child_id {
+//                 return true;
+//             }
+//             if sc.upgrade().is_none() {
+//                 return false;
+//             }
+//             true
+//         });
+//         if self.has_updated() {
+//             self.aggregate_states(channel_controller);
+
+//         }
+        
+
+//     }
+//     // Called to aggregate states from pick first children. Sends a picker to
+//     // the channel based on aggregation
+//     fn aggregate_states (& mut self, channel_controller: &mut WrappedController) {
+//         let current_connectivity_state = self.aggregated_state.clone();
+//         let child_states_vec: Vec<_> = self.child_states().collect();
+//         // Constructing pickers to return
+//         let mut transient_failure_picker = TransientFailurePickers::new("error string I guess".to_string());
+//         let mut connecting_pickers = ConnectingPickers::new();
+//         let mut ready_pickers = ReadyPickers::new();
+
+//         let mut has_idle = false;
+//         let mut is_transient_failure = true;
+
+//         for (child_id, state) in &child_states_vec {
+//             match state.connectivity_state {
+//                 ConnectivityState::Idle => {
+//                     connecting_pickers.add_picker(state.picker.clone());
+//                     has_idle = true;
+//                     is_transient_failure = false;
+//                 }
+//                 ConnectivityState::Connecting  => {
+//                     connecting_pickers.add_picker(state.picker.clone());
+//                     is_transient_failure = false;
+//                 }
+//                 ConnectivityState::Ready => {
+//                     ready_pickers.add_picker(state.picker.clone());
+//                     is_transient_failure = false;
+//                 }
+//                 ConnectivityState::TransientFailure =>{
+//                     transient_failure_picker.add_picker(state.picker.clone());
+//                 }
+//             }
+//         }
+
+//         let has_ready = ready_pickers.has_any();
+//         let has_connecting = connecting_pickers.pickers.len() >= 1;
+        
+
+//         // Decide the new aggregate state
+//         let new_state = if has_ready {
+//             ConnectivityState::Ready
+//         }  else if has_connecting {
+//             ConnectivityState::Connecting
+//         } else if is_transient_failure{
+//             ConnectivityState::TransientFailure
+//         } else{
+//             ConnectivityState::Connecting
+//         };
+
+//         self.aggregated_state = new_state;
+
+       
+
+//         // Now update state and send picker as appropriate
+//         match new_state {
+//             ConnectivityState::Ready => {
+//                 let pickers_vec = ready_pickers.pickers.clone();
+//                 let picker: Arc<dyn Picker> = Arc::new(ready_pickers);
+//                 let should_update = !self.compare_prev_to_new_pickers(&self.last_ready_pickers, &pickers_vec);
+
+              
+//                 if should_update || self.aggregated_state != ConnectivityState::Ready {
+//                     println!("child manager sends ready picker update");
+//                     self.aggregated_state = ConnectivityState::Ready;
+//                     self.last_ready_pickers = pickers_vec;
+//                     channel_controller.need_to_reach();
+//                     channel_controller.update_picker(LbState {
+//                         connectivity_state: ConnectivityState::Ready,
+//                         picker,
+//                     });
+//                     println!("connecting state should be false");
+//                     self.sent_connecting_state = false;
+//                 }
+//             }
+//             ConnectivityState::Connecting => {
+//                 if self.aggregated_state == ConnectivityState::TransientFailure
+//                     && new_state != ConnectivityState::Ready
+//                 {
+//                     println!("connecting state should be false");
+//                     return;
+//                 }
+//                 if !self.sent_connecting_state {
+//                     println!("child manager sends connecting picker update");
+                    
+//                     channel_controller.need_to_reach();
+//                     let picker = Arc::new(QueuingPicker{});
+//                     self.move_to_connecting(has_idle, channel_controller, picker);
+//                 } else{
+//                     println!("child manager is not sending connecting picker as it has alrady sent connecting state");
+//                 }
+//                 // Don't send another Connecting picker if already sent
+//             }
+//             ConnectivityState::Idle => {
+//                 self.aggregated_state = ConnectivityState::Connecting;
+//                 let picker = Arc::new(QueuingPicker {});
+//                 channel_controller.need_to_reach();
+//                 channel_controller.update_picker(LbState {
+//                     connectivity_state: ConnectivityState::Connecting,
+//                     picker,
+//                 });
+                
+//                 self.sent_connecting_state = true;
+//             }
+//             ConnectivityState::TransientFailure => {
+//                 if current_connectivity_state != ConnectivityState::TransientFailure{
+//                     println!("child manager sends transient failure picker update");
+//                     let picker = Arc::new(transient_failure_picker);
+//                     channel_controller.need_to_reach();
+//                     self.move_to_transient_failure(channel_controller, picker);
+//                 }
+//             }
+   
+//         }
+//     }
+    
+    
+// }
+
+// impl<T: ChildIdentifier> ChildManager<T> {
+//     fn move_to_transient_failure(&mut self, channel_controller: &mut dyn ChannelController, picker: Arc<dyn Picker>) {
+//         self.aggregated_state = ConnectivityState::TransientFailure;
+//         channel_controller.update_picker(LbState {
+//                 connectivity_state: ConnectivityState::TransientFailure,
+//                picker: picker,
+//             });
+//         println!("requesting resolution");
+//         channel_controller.request_resolution();
+//         self.sent_connecting_state = false;
+//     }
+
+
+
+//     fn move_to_connecting(&mut self, is_idle: bool, channel_controller: &mut dyn ChannelController, picker: Arc<dyn Picker>) {
+//         self.aggregated_state = ConnectivityState::Connecting;
+//         channel_controller.update_picker(LbState {
+//             connectivity_state: ConnectivityState::Connecting,
+//             picker: picker,
+//         });
+//         self.sent_connecting_state = true;
+//         // if is_idle {
+//         //     println!("requesting resolution");
+//         //     channel_controller.request_resolution();
+//         // }
+//     }
+
+//     fn compare_prev_to_new_pickers(& self, old_pickers: &[Arc<dyn Picker>], new_pickers: &[Arc<dyn Picker>]) -> bool {
+//         //if length is different, then definitely not the same picker
+//         if old_pickers.len() != new_pickers.len() {
+//             return false;
+//         }
+//         //compares two vectors of pickers by pointer equality and returns true if all pickers are the same 
+//         for (x, y) in old_pickers.iter().zip(new_pickers.iter()) {
+//             if !Arc::ptr_eq(x, y) {
+//                 return false;
+//             }
+//         }
+//         true
+//     }
+// }
+
+// impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
+//     fn resolver_update(
+//         &mut self,
+//         resolver_update: ResolverUpdate,
+//         config: Option<&LbConfig>,
+//         channel_controller: &mut dyn ChannelController,
+//     ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+//         // First determine if the incoming update is valid.
+//         if let Err(error) = &resolver_update.endpoints {
+//             let has_usable_children = self.children.values().any(|child| {
+//                 matches!(
+//                     child.state.connectivity_state,
+//                     ConnectivityState::Ready | ConnectivityState::Connecting | ConnectivityState::Idle
+//                 )
+//             });
+//             if !has_usable_children || self.aggregated_state == ConnectivityState::TransientFailure {
+//                 let picker = Arc::new(TransientFailurePickers::new(error.to_string()));
+//                 self.move_to_transient_failure(channel_controller, picker);
+//             }
+//             return Ok(());
+//         }
+//         if let Ok(ref endpoints) = resolver_update.endpoints {
+//             if endpoints.is_empty() {
+//                 // No endpoints present
+//                 let error = "resolver update received no endpoints";
+//                 let picker = Arc::new(TransientFailurePickers::new(error.to_string()));
+//                 println!("Resolver update has no endpoints!");
+//                 self.move_to_transient_failure(channel_controller, picker);
+//                 return Err("received empty address list from the name resolver".into());
+//             }
+//         }
+//         let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+//         let child_updates = self.sharder.shard_update(resolver_update)?;
+
+//         self.children
+//             .retain(|child_id, _| child_updates.contains_key(child_id));
+       
+//         for (id, update) in child_updates.into_iter() {
+//             let child_id: Arc<T> = Arc::new(id);
+//             let child_policy: &mut dyn LbPolicy = match self.children.get_mut(&child_id) {
+//                 Some(child) => child.policy.as_mut(),
+//                 None => {
+//                     println!("creating a new child for {}", child_id.clone());
+//                     self.children.insert(
+//                         child_id.clone(),
+//                         Child {
+//                             policy: update.child_policy_builder.build(LbPolicyOptions {
+//                                 work_scheduler: Arc::new(ChildScheduler::new(
+//                                     child_id.clone(),
+//                                     self.work_scheduler.clone(),
+//                                     self.work_requests.clone(),
+//                                 )),
+//                             }),
+//                             state: LbState::initial(),
+//                         },
+//                     );
+//                     self.children.get_mut(&child_id).unwrap().policy.as_mut()
+//                 }
+//             };
+            
+
+//             let _ = child_policy.resolver_update(
+//                 update.child_update.clone(),
+//                 config,
+//                 &mut wrapped_channel_controller,
+//             );
+//             self.resolve_child_controller(&mut wrapped_channel_controller, child_id.clone());
+//         }
+
+//         // Keep only the subchannels associated with currently active children.
+//         self.subchannels
+//             .retain(|_, child_id| self.children.contains_key(child_id));
+//         Ok(())
+//     }
+
+//     fn subchannel_update(
+//         &mut self,
+//         subchannel: Arc<dyn Subchannel>,
+//         state: &SubchannelState,
+//         channel_controller: &mut dyn ChannelController,
+//     ) {
+//         // Determine which child created this subchannel.
+//         let child_id = self
+//             .subchannels
+//             .get(&WeakSubchannel::new(subchannel.clone()))
+//             .unwrap_or_else(|| {
+//                 panic!("Subchannel not found in child manager: {}", subchannel);
+//             });
+        
+//         println!("child id mapped for subchannel {} is child_id {}", subchannel, child_id);
+//         let policy = &mut self.children.get_mut(&child_id.clone()).unwrap().policy;
+
+//         // Wrap the channel_controller to track the child's operations.
+//         let mut channel_controller = WrappedController::new(channel_controller);
+//         // Call the proper child.
+//         policy.subchannel_update(subchannel, state,  &mut channel_controller);
+//         self.resolve_child_controller(&mut channel_controller, child_id.clone());
+//     }
+
+//     fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+//         let children = mem::take(&mut *self.work_requests.lock().unwrap());
+//         // It is possible that work was queued for a child that got removed as
+//         // part of a subsequent resolver_update. So, it is safe to ignore such a
+//         // child here.
+//         for child_id in children {
+//             if let Some(child) = self.children.get_mut(&child_id) {
+//                 let mut channel_controller = WrappedController::new(channel_controller);
+//                 child.policy.work(&mut channel_controller);
+//                 self.resolve_child_controller(&mut channel_controller, child_id.clone());
+//             }
+//         }
+//     }
+    
+//     fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+//         todo!()
+//         // let policy = &mut self.children.get_mut(&child_id.clone()).unwrap().policy;
+//         // let mut channel_controller = WrappedController::new(channel_controller);
+//         // // Call the proper child.
+//         // policy.exit_idle(&mut channel_controller);
+//         // self.resolve_child_controller(channel_controller, child_id.clone());
+//     }
+// }
+
+// struct WrappedController<'a> {
+//     channel_controller: &'a mut dyn ChannelController,
+//     created_subchannels: Vec<Arc<dyn Subchannel>>,
+//     picker_update: Option<LbState>,
+//     need_to_reach: bool,
+// }
+
+// impl<'a> WrappedController<'a> {
+//     fn new(channel_controller: &'a mut dyn ChannelController) -> Self {
+//         Self {
+//             channel_controller,
+//             created_subchannels: vec![],
+//             picker_update: None,
+//             need_to_reach: false,
+//         }
+//     }
+
+//     fn need_to_reach(&mut self) {
+//         self.need_to_reach = true;
+//     }
+// }
+
+// impl ChannelController for WrappedController<'_> {
+//     fn new_subchannel(&mut self, address: &Address) -> Arc<dyn Subchannel> {
+//         let subchannel = self.channel_controller.new_subchannel(address);
+//         self.created_subchannels.push(subchannel.clone());
+//         subchannel
+//     }
+
+//     fn update_picker(&mut self, update: LbState) {
+//             self.picker_update = Some(update.clone());
+//             if self.need_to_reach{
+//                 self.channel_controller.update_picker(update);
+//                 self.need_to_reach = false;
+//             }
+//         }
+
+//     fn request_resolution(&mut self) {
+//         self.channel_controller.request_resolution();
+//     }
+// }
+
+// struct ChildScheduler<T: ChildIdentifier> {
+//     child_identifier: Arc<T>,
+//     work_requests: Arc<Mutex<HashSet<Arc<T>>>>,
+//     work_scheduler: Arc<dyn WorkScheduler>,
+// }
+
+// impl<T: ChildIdentifier> ChildScheduler<T> {
+//     fn new(
+//         child_identifier: Arc<T>,
+//         work_scheduler: Arc<dyn WorkScheduler>,
+//         work_requests: Arc<Mutex<HashSet<Arc<T>>>>,
+//     ) -> Self {
+//         Self {
+//             child_identifier,
+//             work_requests,
+//             work_scheduler,
+//         }
+//     }
+// }
+
+// impl<T: ChildIdentifier> WorkScheduler for ChildScheduler<T> {
+//     fn schedule_work(&self) {
+//         (*self.work_requests.lock().unwrap()).insert(self.child_identifier.clone());
+//         self.work_scheduler.schedule_work();
+//     }
+// }
+
+// struct ReadyPickers {
+//     pickers: Vec<Arc<dyn Picker>>,
+//     next: AtomicUsize,
+// }
+
+
+
+// impl ReadyPickers {
+//     pub fn new() -> Self {
+//         Self {
+//             pickers: vec![],
+//             next: AtomicUsize::new(0),
+//         }
+//     }
+
+//     fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+//         self.pickers.push(picker);
+//     }
+
+//     pub fn has_any(&self) -> bool {
+//         !self.pickers.is_empty()
+//     }
+
+    
+// }
+
+// impl Picker for ReadyPickers {
+//     fn pick(&self, request: &Request) -> PickResult {
+//         let len = self.pickers.len();
+//         if len == 0 {
+//             return PickResult::Queue;
+//         }
+//         let idx = self.next.fetch_add(1, Ordering::Relaxed) % len;
+//         self.pickers[idx].pick(request)
+//     }
+
+    
+// }
+// struct ConnectingPickers {
+//     pickers: Vec<Arc<dyn Picker>>,
+//     // next: AtomicUsize,
+// }
+
+// impl Picker for ConnectingPickers {
+//     fn pick(&self, request: &Request) -> PickResult {
+        
+//         return PickResult::Queue;
+        
+//     }
+// }
+
+// impl ConnectingPickers {
+//     pub fn new() -> Self {
+//         Self {
+//             pickers: vec![],
+//         }
+//     }
+
+//     fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+//         self.pickers.push(picker);
+//     }
+// }
+
+// struct TransientFailurePickers {
+//     pickers: Vec<Arc<dyn Picker>>,
+//     error: String,    
+
+// }
+
+// impl Picker for TransientFailurePickers {
+//     fn pick(&self, request: &Request) -> PickResult {
+        
+//         return PickResult::Fail(Status::unavailable(self.error.clone()))
+        
+//     }
+// }
+
+// impl TransientFailurePickers {
+//     pub fn new(error: String) -> Self {
+//         Self {
+//             pickers: vec![],
+//             error,
+//         }
+//     }
+
+//     fn add_picker(&mut self, picker: Arc<dyn Picker>)  {
+//         self.pickers.push(picker);
+//     }
+// }
+// struct IdlePickers {
+//     pickers: Vec<Arc<dyn Picker>>,
+//     work_scheduler: Arc<dyn WorkScheduler>,
+//     // next: AtomicUsize,
+// }
+
+// struct SchedulingIdlePicker {
+//     work_scheduler: Arc<dyn WorkScheduler>,
+// }
+
+// impl Picker for SchedulingIdlePicker {
+//     fn pick(&self, _request: &Request) -> PickResult {
+//         self.work_scheduler.schedule_work();
+//         PickResult::Queue
+//     }
+// }
+
+
 /*
  *
  * Copyright 2025 gRPC authors.
@@ -29,9 +656,7 @@ use std::sync::Mutex;
 use std::{collections::HashMap, error::Error, hash::Hash, mem, sync::Arc};
 
 use crate::client::load_balancing::{
-    ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
-    LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
-    Subchannel, SubchannelState, WeakSubchannel, WorkScheduler, GLOBAL_LB_REGISTRY, ConnectivityState,
+    ChannelController, ConnectivityState, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker, Subchannel, SubchannelState, WeakSubchannel, WeakSubchannelMap, WorkScheduler, GLOBAL_LB_REGISTRY
 };
 use crate::client::name_resolution::{Address, ResolverUpdate};
 use crate::service::{Message, Request, Response, Service};
@@ -43,7 +668,8 @@ use tokio::task::{AbortHandle, JoinHandle};
 
 // An LbPolicy implementation that manages multiple children.
 pub struct ChildManager<T> {
-    subchannels: HashMap<WeakSubchannel, Arc<T>>,
+    subchannel_child_map: WeakSubchannelMap<usize>,
+    // subchannels: HashMap<WeakSubchannel, Arc<T>>,
     children: HashMap<Arc<T>, Child>,
     sharder: Box<dyn ResolverUpdateSharder<T>>,
     updated: bool, // true iff a child has updated its state since the last call to has_updated.
@@ -166,15 +792,19 @@ impl<T: ChildIdentifier> ChildManager<T> {
         
 
     }
-
+    // Called to aggregate states from pick first children. Sends a picker to
+    // the channel based on aggregation
     fn aggregate_states (& mut self, channel_controller: &mut WrappedController) {
         let current_connectivity_state = self.aggregated_state.clone();
         let child_states_vec: Vec<_> = self.child_states().collect();
+        // Constructing pickers to return
         let mut transient_failure_picker = TransientFailurePickers::new("error string I guess".to_string());
         let mut connecting_pickers = ConnectingPickers::new();
         let mut ready_pickers = ReadyPickers::new();
+
         let mut has_idle = false;
         let mut is_transient_failure = true;
+
         for (child_id, state) in &child_states_vec {
             match state.connectivity_state {
                 ConnectivityState::Idle => {
@@ -193,8 +823,6 @@ impl<T: ChildIdentifier> ChildManager<T> {
                 ConnectivityState::TransientFailure =>{
                     transient_failure_picker.add_picker(state.picker.clone());
                 }
-                
-               
             }
         }
 
@@ -212,8 +840,8 @@ impl<T: ChildIdentifier> ChildManager<T> {
         } else{
             ConnectivityState::Connecting
         };
+
         self.aggregated_state = new_state;
-        println!("new state is {}", new_state);
 
        
 
@@ -224,10 +852,7 @@ impl<T: ChildIdentifier> ChildManager<T> {
                 let picker: Arc<dyn Picker> = Arc::new(ready_pickers);
                 let should_update = !self.compare_prev_to_new_pickers(&self.last_ready_pickers, &pickers_vec);
 
-                // let should_update = match &self.picker {
-                //     Some(existing_picker) => !Arc::ptr_eq(existing_picker, &picker),
-                //     None => true,
-                // };
+              
                 if should_update || self.aggregated_state != ConnectivityState::Ready {
                     println!("child manager sends ready picker update");
                     self.aggregated_state = ConnectivityState::Ready;
@@ -359,21 +984,11 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
             }
         }
         let mut wrapped_channel_controller = WrappedController::new(channel_controller);
-        println!("calling shard update");
         let child_updates = self.sharder.shard_update(resolver_update)?;
-        // Remove children that are no longer active.
-        println!("Before children keys:");
-        for (child_id, _) in &self.children {
-            println!("  {}", child_id);
-        }
+
         self.children
             .retain(|child_id, _| child_updates.contains_key(child_id));
-        println!("Current children keys:");
-        for (child_id, _) in &self.children {
-            println!("  {}", child_id);
-        }
-        // Apply child updates to respective policies, instantiating new ones as
-        // needed.
+       
         for (id, update) in child_updates.into_iter() {
             let child_id: Arc<T> = Arc::new(id);
             let child_policy: &mut dyn LbPolicy = match self.children.get_mut(&child_id) {

--- a/grpc/src/client/load_balancing/child_manager/test.rs
+++ b/grpc/src/client/load_balancing/child_manager/test.rs
@@ -1,0 +1,1073 @@
+// use crate::client::{
+//     load_balancing::{
+//         pick_first::{
+//             self, 
+//         },
+//         round_robin::{
+//             self, 
+//         },
+//         child_manager::{
+//             self, ChildManager,
+//         },
+//         test_utils::{self, FakeChannel, TestEvent, TestWorkScheduler},
+//         ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+//         LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+//         Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
+//     },
+//     name_resolution::{Address, Endpoint, ResolverUpdate},
+//     transport::{Transport, GLOBAL_TRANSPORT_REGISTRY},
+//     ConnectivityState,
+// };
+// use crate::service::{Message, Request, Response, Service};
+// use core::panic;
+// use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+// use serde_json::json;
+// use std::{
+//     ops::Add,
+//     sync::{Arc, Mutex},
+// };
+// use tokio::{
+//     sync::{mpsc, Notify},
+//     task::AbortHandle,
+// };
+// use tonic::async_trait;
+
+
+// struct ResolverUpdateSharderStruct {builder: Arc<dyn LbPolicyBuilder>}
+
+
+// impl ResolverUpdateSharder<Endpoint> for ResolverUpdateSharderStruct {
+//     fn shard_update(
+//         &self,
+//         resolver_update: ResolverUpdate,
+       
+//     ) -> Result<HashMap<Endpoint, ChildUpdate>, Box<dyn Error + Send + Sync>> {
+//         let mut hashmap = HashMap::new();
+//         let builder = self.builder.clone();
+//         for endpoint in resolver_update.endpoints.clone().unwrap().iter() {
+//             println!("endpoint assigned to a child is {}", endpoint);
+//             let child_update = ChildUpdate{
+//                 child_policy_builder: self.builder.clone(),
+//                 //create new resolver update with particular endpoint
+//                 child_update: ResolverUpdate {attributes: resolver_update.attributes.clone(), endpoints: Ok(vec![endpoint.clone()]), service_config: resolver_update.service_config.clone(), resolution_note: resolver_update.resolution_note.clone()},
+//             };
+//             hashmap.insert(endpoint.clone(), child_update);
+//         }
+//         Ok(hashmap)
+//     }
+// }
+// // Sets up the test environment.
+// //
+// // Performs the following:
+// // 1. Creates a work scheduler.
+// // 2. Creates a fake channel that acts as a channel controller.
+// // 3. Creates a pick_first LB policy.
+// //
+// // Returns the following:
+// // 1. A receiver for events initiated by the LB policy (like creating a
+// //    new subchannel, sending a new picker etc).
+// // 2. The LB policy to send resolver and subchannel updates from the test.
+// // 3. The channel to pass to the LB policy as part of the updates.
+
+// //this should be good
+// fn setup() -> (
+//     mpsc::UnboundedReceiver<TestEvent>,
+//     Box<dyn LbPolicy>,
+//     Box<dyn ChannelController>,
+// ) {
+//     pick_first::reg();
+//     round_robin::reg();
+    
+//     let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
+//     let work_scheduler = Arc::new(TestWorkScheduler {
+//         tx_events: tx_events.clone(),
+//     });
+//     // let tcc = Box::new(FakeChannel::new(tx_events.clone()));
+//     let tcc = Box::new(FakeChannel {
+//         tx_events: tx_events.clone(),
+//     });
+//     let resolver_update_sharder = ResolverUpdateSharderStruct {builder:GLOBAL_LB_REGISTRY.get_policy("wrapped_pick_first").unwrap()};
+//     let child_manager = Box::new(ChildManager::<Endpoint>::new(LbPolicyOptions { work_scheduler }, Box::new(resolver_update_sharder)));
+
+//     (rx_events, child_manager, tcc)
+// }
+
+// fn create_endpoint_with_one_address(addr: String) -> Endpoint {
+//     Endpoint {
+//         addresses: vec![Address {
+//             address: addr,
+//             ..Default::default()
+//         }],
+//         ..Default::default()
+//     }
+// }
+
+// // Creates a new endpoint with the specified number of addresses.
+// fn create_endpoint_with_n_addresses(n: usize) -> Endpoint {
+//     let mut addresses = Vec::new();
+//     for i in 0..n {
+//         addresses.push(Address {
+//             address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
+//             ..Default::default()
+//         });
+//     }
+//     Endpoint {
+//         addresses,
+//         ..Default::default()
+//     }
+// }
+
+
+// //todo
+// fn create_n_endpoints_with_n_addresses(n: usize) -> Vec<Endpoint> {
+//     let mut addresses = Vec::new();
+//     let mut endpoints = Vec::new();
+//     for i in 0..n {
+//         let mut n_addresses = Vec::new();
+//         for i in 0..n{
+//             n_addresses.push(Address {
+//                 address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
+//                 ..Default::default()
+//             });
+//         }
+//         addresses.push(n_addresses);
+//     };
+//     for i in 0..n{
+//         endpoints.push(Endpoint {
+//         addresses: addresses[i].clone(),
+//         ..Default::default()
+//     })
+//     };
+//     endpoints
+// }
+
+
+// //todo
+// fn create_n_endpoints_with_k_addresses(n: usize, k: usize) -> Vec<Endpoint> {
+//     let mut addresses = Vec::new();
+//     let mut endpoints = Vec::new();
+//     for i in 0..n {
+//         let mut n_addresses = Vec::new();
+//         for j in 0..k{
+//             n_addresses.push(Address {
+//                 address: format!("{}.{}.{}.{}:{}", j+i, j+i, j+i, j+i, j+i),
+//                 ..Default::default()
+//             });
+//         }
+//         addresses.push(n_addresses);
+//     }
+//     for i in 0..n{
+//         endpoints.push(Endpoint {
+//         addresses: addresses[i].clone(),
+//         ..Default::default()
+//     })
+//     }
+//     endpoints
+// }
+
+
+// fn create_n_endpoint_with_one_address(n: usize) -> Vec<Endpoint> {
+//     let mut endpoints = Vec::new();
+//     for i in 0..n {
+//         let address = Address {
+//             address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
+//             ..Default::default()
+//         };
+//         endpoints.push(Endpoint {
+//         addresses: vec![address.clone()],
+//         ..Default::default()
+//     });
+//     }
+//     endpoints
+// }
+
+
+// // Sends a resolver update to the LB policy with the specified endpoint.
+// fn send_resolver_update_to_policy(
+//     child_manager: &mut dyn LbPolicy,
+//     endpoints: Vec<Endpoint>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     let update = ResolverUpdate {
+//         endpoints: Ok(endpoints.clone()),
+//         ..Default::default()
+//     };
+//     assert!(child_manager.resolver_update(update, None, tcc).is_ok());
+// }
+
+
+// // Sends a resolver error to the LB policy with the specified error message.
+
+// //should be good
+// fn send_resolver_error_to_policy(
+//     child_manager: &mut dyn LbPolicy,
+//     err: String,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     let update = ResolverUpdate {
+//         endpoints: Err(err),
+//         ..Default::default()
+//     };
+//     assert!(child_manager.resolver_update(update, None, tcc).is_ok());
+// }
+
+// // Verifies that the subchannels are created for the given addresses in the
+// // given order. Returns the subchannels created.
+// async fn verify_subchannel_creation_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     addresses: Vec<Address>,
+// ) -> Vec<Arc<dyn Subchannel>> {
+//     println!("verifying subchannel creation");
+//     let mut subchannels = Vec::new();
+//     for address in addresses {
+//         match rx_events.recv().await.unwrap() {
+//             TestEvent::NewSubchannel(addr, sc) => {
+//                 assert!(addr == address.clone());
+//                 subchannels.push(sc);
+//             }
+//             other => panic!("unexpected event {}", other),
+//         };
+//     }
+//     subchannels
+// }
+
+// // Verifies that the subchannels are created for the given addresses in the
+// // given order. Returns the subchannels created.
+// async fn verify_multi_endpoint_subchannel_creation_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     mut addresses: Vec<Address>,
+// ) -> Vec<Arc<dyn Subchannel>> {
+//     println!("verifying subchannel creation");
+//     let mut subchannels = Vec::new();
+//     for _ in 0..addresses.len() {
+//         match rx_events.recv().await.unwrap() {
+//             TestEvent::NewSubchannel(addr, sc) => {
+//                 // Find and remove the address from the expected list
+//                 if let Some(pos) = addresses.iter().position(|a| *a == addr) {
+//                     addresses.remove(pos);
+//                     subchannels.push(sc);
+//                 } else {
+//                     panic!("unexpected subchannel address: {:?}", addr);
+//                 }
+//             }
+//             other => panic!("unexpected event {}", other),
+//         };
+//     }
+//     subchannels
+// }
+// // Sends initial subchannel updates to the LB policy for the given
+// // subchannels, with their state set to IDLE.
+// fn send_initial_subchannel_updates_to_policy(
+//     child_manager: &mut dyn LbPolicy,
+//     subchannels: &[Arc<dyn Subchannel>],
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     for sc in subchannels {
+//         child_manager.subchannel_update(sc.clone(), &SubchannelState::default(), tcc);
+//     }
+// }
+
+// fn move_subchannel_to_idle(
+//     child_manager: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     child_manager.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Idle,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_connecting(
+//     child_manager: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     child_manager.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Connecting,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_ready(
+//     child_manager: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     child_manager.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_transient_failure(
+//     child_manager: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     err: &str,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     child_manager.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::TransientFailure,
+//             last_connection_error: Some(Arc::from(Box::from(err.to_owned()))),
+//         },
+//         tcc,
+//     );
+// }
+
+// // Verifies that a connection attempt is made to the given subchannel.
+// async fn verify_connection_attempt_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     subchannel: Arc<dyn Subchannel>,
+// ) {
+//     println!("Verify connection attempt");
+
+//     let event = rx_events.recv().await.unwrap();
+//     println!("  Subchannel: {}", event);
+//     match event {
+//     // match rx_events.recv().await.unwrap() {
+//         TestEvent::Connect(addr) => {
+//             assert!(addr == subchannel.address());
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+   
+// }
+
+// // Verifies that a call to schedule_work is made by the LB policy.
+// async fn verify_schedule_work_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     println!("verify schedule work from policy");
+
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::ScheduleWork => {}
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+
+// // Verifies that the channel moves to CONNECTING state with a queuing picker.
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_connecting_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+// ) -> Arc<dyn Picker> {
+//     println!("verify connecting picker");
+//     match rx_events.recv().await.unwrap() {
+ 
+//         TestEvent::UpdatePicker(update) => {
+//             println!("connectivity state is {}", update.connectivity_state);
+//             assert!(update.connectivity_state == ConnectivityState::Connecting);
+//             let req = test_utils::new_request();
+//             assert!(update.picker.pick(&req) == PickResult::Queue);
+//             return update.picker.clone();
+//         }
+//         other => panic!("unexpected event {}", other),
+//     }
+    
+// }
+
+// // Verifies that the channel moves to READY state with a picker that returns the
+// // given subchannel.
+// //
+// // Returns the picker for tests to make more picks, if required.
+
+// //need to update this? only takes care of one subchannel
+// async fn verify_ready_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     subchannel: Arc<dyn Subchannel>,
+// ) -> Arc<dyn Picker> {
+//     println!("verify ready picker");
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             println!("connectivity state for ready picker is {}", update.connectivity_state);
+//             assert!(update.connectivity_state == ConnectivityState::Ready);
+//             let req = test_utils::new_request();
+//             match update.picker.pick(&req) {
+//                 PickResult::Pick(pick) => {
+//                     assert!(pick.subchannel == subchannel.clone());
+//                     update.picker.clone()
+//                 }
+//                 other => panic!("unexpected pick result {}", other),
+//             }
+//         }
+//         other => panic!("unexpected event {}", other),
+//     }
+// }
+
+
+
+// // Verifies that the channel moves to TRANSIENT_FAILURE state with a picker
+// // that returns an error with the given message. The error code should be
+// // UNAVAILABLE..
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_transient_failure_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     want_error: String,
+// ) -> Arc<dyn Picker> {
+//     let picker = match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::TransientFailure);
+//             let req = test_utils::new_request();
+//             match update.picker.pick(&req) {
+//                 PickResult::Fail(status) => {
+//                     assert!(status.code() == tonic::Code::Unavailable);
+//                     // assert!(status.message().contains(&want_error));
+//                     update.picker.clone()
+//                 }
+//                 other => panic!("unexpected pick result {}", other),
+//             }
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::RequestResolution => {}
+//         _ => panic!("no re-resolution requested after moving to transient_failure"),
+//     }
+//     picker
+
+// }
+
+// // Verifies that the channel moves to IDLE state.
+// async fn verify_channel_moves_to_idle(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::Idle);
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// // Verifies that the LB policy requests re-resolution.
+// async fn verify_resolution_request(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     println!("verifying resolution request");
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::RequestResolution => {}
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// const DEFAULT_TEST_SHORT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+// async fn verify_no_activity_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     tokio::select! {
+//         _ = tokio::time::sleep(DEFAULT_TEST_SHORT_TIMEOUT) => {}
+//         event = rx_events.recv() => {
+//             panic!("unexpected event {}", event.unwrap());
+//         }
+//     }
+// }
+
+// // Tests the scenario where the resolver returns an error before a valid update.
+// // The LB policy should move to TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn roundrobin_resolver_error_before_a_valid_update() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(child_manager, resolver_error.clone(), tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+// }
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy has moved to READY. The LB policy should ignore the error
+// // and continue using the previously received update.
+// #[tokio::test]
+// async fn roundrobin_resolver_error_after_a_valid_update_in_ready() {
+//     //TODO: think about whether to use a bool for the general thing or not
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let failed = true;
+//     //iterate through endpoints here add it to a vec of vecs
+//     // for endpoint in &endpoints{
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+
+    
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    
+
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+
+//     println!("verrifying ready picker");
+//     let picker = verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     let picker = verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+
+//     println!("resolver error");
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(child_manager, resolver_error.clone(), tcc);
+
+//     verify_no_activity_from_policy(&mut rx_events).await;
+
+//     let req = test_utils::new_request();
+//     match picker.pick(&req) {
+//         PickResult::Pick(pick) => {
+//             assert!(pick.subchannel == subchannels[0].clone());
+//         }
+//         other => panic!("unexpected pick result {}", other),
+//     }
+// }
+
+
+// //look at either go or java and both and see the list of tests that they have...
+// //come up with that list and start writing tests.
+
+// //first few tests are hard
+
+// //
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy is still trying to connect. The LB policy should ignore the
+// // error and continue using the previously received update.
+
+// //use debug macro
+
+// #[tokio::test]
+// async fn roundrobin_resolver_error_after_a_valid_update_in_connecting() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     println!("created endpoint");
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     println!("send_resolver_update_to_policy");
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+//     println!("printing subchannels created in the test");
+//     for sc in &subchannels {
+//         println!("  Subchannel: {}", sc);
+//     }
+//     println!("verifying subchannel creation");
+//     println!("calling send_initial_subchannel_updates_to_policy");
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+//     // verify_connecting_picker_from_policy(&mut rx_events).await;
+//     println!("send_initial_subchannel_updates_to_policy");
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     let picker = verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+    
+    
+//     // verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     println!("verify_connection_attempt_from_policy");
+    
+
+    
+
+//     println!("move_subchannel_to_connecting");
+//     //this is not happening... need to fix this so either child manager or child manager
+//     println!("verify_connecting_picker_from_policy");
+//     // verify_connecting_picker_from_policy(&mut rx_events).await;
+//     //no capture with cargo test
+//     let resolver_error = String::from("resolver error");
+
+//     println!("send resolver error");
+//     send_resolver_error_to_policy(child_manager, resolver_error.clone(), tcc);
+
+//     println!("verify no activity from policy");
+//     verify_no_activity_from_policy(&mut rx_events).await;
+
+//     println!("check pick result");
+//     let req = test_utils::new_request();
+//     match picker.pick(&req) {
+//         PickResult::Queue => {}
+//         other => panic!("unexpected pick result {}", other),
+//     }
+// }
+
+
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy has moved to TRANSIENT_FAILURE after attemting to connect
+// // to all addresses.  The LB policy should send a new picker that returns the
+// // error from the resolver.
+// // #[tokio::test]
+// // async fn roundrobin_resolver_error_after_a_valid_update_in_tf() {
+// //     let (mut rx_events, mut child_manager, mut tcc) = setup();
+// //     let child_manager = child_manager.as_mut();
+// //     let tcc = tcc.as_mut();
+
+// //     let endpoint = create_endpoint_with_n_addresses(2);
+// //     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+// //     let subchannels =
+// //         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+// //     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+// //     verify_connecting_picker_from_policy(&mut rx_events).await;
+// //     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    
+    
+// //     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+// //     verify_connecting_picker_from_policy(&mut rx_events).await;
+    
+
+// //     let connection_error = String::from("test connection error");
+// //     move_subchannel_to_transient_failure(child_manager, subchannels[0].clone(), &connection_error, tcc);
+    
+// //     move_subchannel_to_connecting(child_manager, subchannels[1].clone(), tcc);
+// //     // verify_connecting_picker_from_policy(&mut rx_events).await;
+// //     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    
+// //     move_subchannel_to_transient_failure(child_manager, subchannels[1].clone(), &connection_error, tcc);
+// //     verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
+
+// //     let resolver_error = String::from("resolver error");
+// //     send_resolver_error_to_policy(child_manager, resolver_error.clone(), tcc);
+// //     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+// // }
+// // Tests the scenario where the resolver returns an update with no addresses
+// // (before sending any valid update). The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker.
+
+// //hi, consider creating a function where there are n endpoints with j addresses to test for
+// //having endpoints but with 0 addresses
+
+// #[tokio::test]
+// async fn roundrobin_simple_test() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[1].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    
+// }
+
+// #[tokio::test]
+// async fn roundrobin_logic_simple_test() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+
+//     let endpoints = create_n_endpoints_with_k_addresses(2, 1);
+//     send_resolver_update_to_policy(child_manager, endpoints.clone(), tcc);
+    
+//     let first_addresses: Vec<_> = endpoints[0].addresses.clone();
+//     let second_addresses: Vec<_> = endpoints[1].addresses.clone();
+//     // verify_connecting_picker_from_policy(&mut rx_events).await;
+//     let first_subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, first_addresses.clone()).await;
+//     let second_subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, second_addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &first_subchannels, tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     // for sc in &subchannels {
+//     //     move_subchannel_to_connecting(child_manager, sc.clone(), tcc);
+//     //     verify_connection_attempt_from_policy(&mut rx_events, sc.clone()).await;
+//     // }
+
+//     // move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+//     // verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     // for sc in subchannels.iter().skip(1) {
+//     //     move_subchannel_to_ready(child_manager, sc.clone(), tcc);
+//     //     verify_ready_picker_from_policy(&mut rx_events, sc.clone()).await;
+//     // }
+    
+// }
+
+// #[tokio::test]
+// async fn roundrobin_zero_addresses_from_resolver_before_valid_update() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+
+//     let endpoints = create_n_endpoints_with_k_addresses(4, 0);
+//     let update = ResolverUpdate {
+//         endpoints: Ok(endpoints.clone()),
+//         ..Default::default()
+//     };
+//     assert!(child_manager.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// #[tokio::test]
+// async fn roundrobin_stay_transient_failure_until_ready() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+    
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+    
+    
+    
+//     move_subchannel_to_connecting(child_manager, subchannels[1].clone(), tcc);
+//     let first_error = String::from("test connection error 1");
+//     for sc in &subchannels {
+//         move_subchannel_to_transient_failure(child_manager, sc.clone(), &first_error, tcc);
+        
+
+//     }
+
+ 
+//     println!("verifying transient failure picker");
+    
+//     verify_transient_failure_picker_from_policy(&mut rx_events, first_error.clone()).await;
+//     println!("verifying resolution request");
+//     // verify_transient_failure_picker_from_policy(&mut rx_events, first_error.clone()).await;
+
+    
+//     println!("moving subchannel to ready");
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+   
+
+
+
+//     println!("verifying subchannel to ready");
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+// // Tests the scenario where the resolver returns an update with no endpoints
+// // (before sending any valid update). The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker.
+
+// //should be good to go
+// #[tokio::test]
+// async fn roundrobin_zero_endpoints_from_resolver_before_valid_update() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![]),
+//         ..Default::default()
+//     };
+//     assert!(child_manager.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with no endpoints
+// // after sending a valid update (and the LB policy has moved to READY). The LB
+// // policy should move to TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn roundrobin_zero_endpoints_from_resolver_after_valid_update() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+    
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+   
+
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    
+
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![]),
+//         ..Default::default()
+//     };
+//     assert!(child_manager.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with one address. The
+// // LB policy should create a subchannel for that address, connect to it, and
+// // once the connection succeeds, move to READY state with a picker that returns
+// // that subchannel.
+// #[tokio::test]
+// async fn roundrobin_with_one_backend() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(1);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+
+   
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    
+
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // address. The LB policy should create subchannels for all address, and attempt
+// // to connect to them in order, until a connection succeeds, at which point it
+// // should move to READY state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn roundrobin_with_multiple_backends_first_backend_is_ready() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+
+    
+
+
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+    
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // address, some of which are duplicates. The LB policy should dedup the
+// // addresses and create subchannels for them, and attempt to connect to them in
+// // order, until a connection succeeds, at which point it should move to READY
+// // state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn roundrobin_with_multiple_backends_duplicate_addresses() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = Endpoint {
+//         addresses: vec![
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+//                 ..Default::default()
+//             },
+//         ],
+//         ..Default::default()
+//     };
+//     let endpoint_with_duplicates_removed = Endpoint {
+//         addresses: vec![
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+//                 ..Default::default()
+//             },
+//         ],
+//         ..Default::default()
+//     };
+
+//     send_resolver_update_to_policy(child_manager, vec![endpoint.clone()], tcc);
+//     let subchannels = verify_subchannel_creation_from_policy(
+//         &mut rx_events,
+//         endpoint_with_duplicates_removed.addresses.clone(),
+//     )
+//     .await;
+
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+    
+//     let connection_error = String::from("test connection error");
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(child_manager, subchannels[0].clone(), &connection_error, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[1].clone(), tcc);
+//     move_subchannel_to_ready(child_manager, subchannels[1].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
+// }
+
+
+
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a new address list that
+// // contains the address of the currently connected subchannel. The LB policy
+// // should create subchannels for the new addresses, and then see that the
+// // currently connected subchannel is in the new address list. It should then
+// // send a new READY picker that returns the currently connected subchannel.
+// #[tokio::test]
+// async fn roundrobin_resolver_update_contains_currently_ready_subchannel() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+    
+    
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+    
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let mut endpoints = create_endpoint_with_n_addresses(4);
+//     endpoints.addresses.reverse();
+//     send_resolver_update_to_policy(child_manager, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     child_manager.subchannel_update(subchannels[0].clone(), &SubchannelState::default(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     child_manager.subchannel_update(subchannels[1].clone(), &SubchannelState::default(), tcc);
+
+//     child_manager.subchannel_update(subchannels[2].clone(), &SubchannelState::default(), tcc);
+//     child_manager.subchannel_update(
+//         subchannels[3].clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[3].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a an address list that is
+// // identical to the first update. The LB policy should create subchannels for
+// // the new addresses, and then see that the currently connected subchannel is in
+// // the new address list. It should then send a new READY picker that returns the
+// // currently connected subchannel.
+// #[tokio::test]
+// async fn roundrobin_resolver_update_contains_identical_address_list() {
+//     let (mut rx_events, mut child_manager, mut tcc) = setup();
+//     let child_manager = child_manager.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(child_manager, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    
+//     send_initial_subchannel_updates_to_policy(child_manager, &subchannels, tcc);
+    
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(child_manager, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(child_manager, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     send_resolver_update_to_policy(child_manager, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     child_manager.subchannel_update(
+//         subchannels[0].clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+
+

--- a/grpc/src/client/load_balancing/graceful_switch.rs
+++ b/grpc/src/client/load_balancing/graceful_switch.rs
@@ -1,0 +1,385 @@
+use crate::client::{
+    channel::{InternalChannelController, WorkQueueItem, WorkQueueTx}, load_balancing::{
+        child_manager::{
+            self, 
+        }, pick_first::{
+            self, 
+        }, ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker, Subchannel, SubchannelState, WeakSubchannel, WorkScheduler, GLOBAL_LB_REGISTRY
+    }, name_resolution::{Address, Endpoint, ResolverUpdate}, transport::{Transport, GLOBAL_TRANSPORT_REGISTRY}, ConnectivityState
+    
+};
+
+
+use std::{collections::{HashMap, HashSet}, error::Error, hash::Hash, mem, sync::{atomic::{AtomicUsize, Ordering}, Arc}};
+
+use crate::service::{Message, Request, Response, Service};
+use core::panic;
+use serde_json::json;
+use std::{
+    ops::Add,
+    sync::{ Mutex},
+};
+use tokio::{
+    sync::{mpsc, Notify},
+    task::AbortHandle,
+};
+
+use crate::client::load_balancing::child_manager::ChildManager;
+
+use once_cell::sync::Lazy;
+use rand::{self, rngs::StdRng, seq::SliceRandom, thread_rng, Rng, RngCore, SeedableRng};
+use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
+use tonic::{async_trait, metadata::MetadataMap};
+use crate::client::load_balancing::child_manager::ChildUpdate;
+
+use crate::client::load_balancing::child_manager::ResolverUpdateSharder;
+use crate::client::load_balancing::Pick;
+
+
+pub static POLICY_NAME: &str = "round_robin";
+
+#[cfg(test)]
+mod test;
+
+// impl WorkScheduler for GracefulSwitchPolicy {
+//     fn schedule_work(&self) {
+//         if mem::replace(&mut *self.pending.lock().unwrap(), true) {
+//             // Already had a pending call scheduled.
+//             return;
+//         }
+//         let _ = self.work_scheduler.send(WorkQueueItem::Closure(Box::new(
+//             |c: &mut InternalChannelController| {
+//                 *c.lb.pending.lock().unwrap() = false;
+//                 c.lb.clone()
+//                     .policy
+//                     .lock()
+//                     .unwrap()
+//                     .as_mut()
+//                     .unwrap()
+//                     .work(c);
+//             },
+//         )));
+//     }
+// }
+
+#[derive(Deserialize)]
+pub(super) struct GracefulSwitchConfig {
+    children_policies: Vec<HashMap<String, serde_json::Value>>,
+}
+
+pub(super) struct GracefulSwitchLbConfig {
+    child_builder: Arc<dyn LbPolicyBuilder>,
+    child_config: LbConfig,
+}
+
+impl GracefulSwitchLbConfig{
+    fn new(child_builder: Arc<dyn LbPolicyBuilder>, child_config: LbConfig) -> Self{
+        GracefulSwitchLbConfig{
+            child_builder,
+            child_config,
+        }
+    }
+}
+/** 
+struct for round_robin
+*/
+//wrap pick first in a LB policy that calls ExitIdle whenever a subchannel disconnects
+struct GracefulSwitchPolicy {
+    // mutex: Mutex<Arc<dyn LbPolicy>>,
+    // current_mutex: Mutex<Arc<dyn LbPolicy>>,
+    subchannel_to_policy: HashMap<WeakSubchannel, ChildKind>,
+    current_policy: Mutex<Option<Box<dyn LbPolicy>>>,
+    pending_policy: Mutex<Option<Box<dyn LbPolicy>>>,
+    current_policy_state: Mutex<Option<ConnectivityState>>,
+    pending_policy_state: Mutex<Option<ConnectivityState>>,
+    closed: bool,
+    work_scheduler: Arc<dyn WorkScheduler>,
+    pending: bool,
+    
+}
+
+impl LbPolicy for GracefulSwitchPolicy{
+    fn resolver_update(
+        &mut self,
+        update: ResolverUpdate,
+        config: Option<&LbConfig>,
+        channel_controller: &mut dyn ChannelController,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        if update.service_config.as_ref().is_ok_and(|sc| sc.is_some()) {
+            return Err("can't do service configs yet".into());
+        }
+        let current_policy_is_none = {
+            let current_policy = self.current_policy.lock().unwrap();
+            current_policy.is_none()
+        };
+        let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+        let update_clone = update.clone();
+        if current_policy_is_none {
+            self.switch_to(update, config);
+        }
+        if let Some(ref mut pending_policy) = *self.pending_policy.lock().unwrap() {
+            pending_policy.resolver_update(update_clone, config, &mut wrapped_channel_controller)?;
+        }
+        self.resolve_child_controller(&mut wrapped_channel_controller, ChildKind::Pending);
+        // let child_policy = self.pending_policy.lock().unwrap().as_ref().map(|p| p.as_ref());
+        Ok(())
+    }
+
+    fn subchannel_update(
+        &mut self,
+        subchannel: Arc<dyn Subchannel>,
+        state: &SubchannelState,
+        channel_controller: &mut dyn ChannelController,
+    ) {
+        let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+        let which_child = self
+        .subchannel_to_policy
+        .get(&WeakSubchannel::new(subchannel.clone()))
+        .unwrap_or_else(|| {
+            panic!("Subchannel not found in child manager: {}", subchannel);
+        }).clone(); // Clone the ChildKind
+        // let current_policy_state = 
+        
+
+        match which_child {
+            ChildKind::Pending => {
+                if let Some(ref mut pending_policy) = *self.pending_policy.lock().unwrap() {
+                    pending_policy.subchannel_update(subchannel, state, &mut wrapped_channel_controller);
+                    // self.resolve_child_controller(&mut wrapped_channel_controller, ChildKind::Pending);
+                }
+            }
+            ChildKind::Current => {
+                if let Some(ref mut current_policy) = *self.current_policy.lock().unwrap() {
+                    current_policy.subchannel_update(subchannel, state, &mut wrapped_channel_controller);
+                    // self.resolve_child_controller(&mut wrapped_channel_controller, ChildKind::Current);
+                }
+            }
+        }
+
+        let current_state = self.current_policy_state.lock().unwrap().clone();
+        let pending_state = self.pending_policy_state.lock().unwrap().clone();
+
+        let should_swap = match (current_state, pending_state) {
+            (Some(ConnectivityState::Ready), Some(ConnectivityState::Connecting)) => false,
+            (Some(ConnectivityState::Ready), Some(pending)) if pending != ConnectivityState::Connecting => true,
+            (Some(current), _) if current != ConnectivityState::Ready => true,
+            _ => false,
+        };
+
+        if should_swap {
+            // Promote pending to current
+            let mut current_policy = self.current_policy.lock().unwrap();
+            let mut pending_policy = self.pending_policy.lock().unwrap();
+            *current_policy = pending_policy.take();
+            *self.current_policy_state.lock().unwrap() = self.pending_policy_state.lock().unwrap().take();
+            // Optionally clear subchannel_to_policy for old current, etc.
+        }
+
+    // self.resolve_child_controller(&mut wrapped_channel_controller, which_child);
+        self.resolve_child_controller(&mut wrapped_channel_controller, which_child);
+    }
+
+    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+        if let Some(ref mut pending_policy) = *self.pending_policy.lock().unwrap() {
+            pending_policy.work(channel_controller);
+        } else if let Some(ref mut current_policy) = *self.current_policy.lock().unwrap() {
+            current_policy.work(channel_controller);
+        }
+    }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        if let Some(ref mut pending_policy) = *self.pending_policy.lock().unwrap() {
+            pending_policy.exit_idle(channel_controller);
+        } else if let Some(ref mut current_policy) = *self.current_policy.lock().unwrap() {
+            current_policy.exit_idle(channel_controller);
+        }
+    }
+}
+
+#[derive(PartialEq, Eq, Clone)]
+enum ChildKind {
+    Current,
+    Pending,
+}
+
+impl GracefulSwitchPolicy {
+    pub fn new(
+        work_scheduler: Arc<dyn WorkScheduler>,
+    ) -> Self {
+        GracefulSwitchPolicy { 
+            // mutex: Mutex<Arc<dyn LbPolicy>>,
+            // current_mutex: Mutex<Arc<dyn LbPolicy>>,
+            subchannel_to_policy: HashMap::default(),
+            current_policy: Mutex::default(),
+            pending_policy: Mutex::default(),
+            current_policy_state: Mutex::new(None), 
+            pending_policy_state: Mutex::new(None),
+            closed: false,
+            work_scheduler: work_scheduler,
+            pending: false,
+        }
+    }
+
+    fn resolve_child_controller(
+        &mut self,
+        channel_controller: &mut WrappedController,        
+        child_kind: ChildKind,
+    ) {
+        // Add all created subchannels into the subchannel_child_map.
+        for csc in channel_controller.created_subchannels.clone() {
+            let key = WeakSubchannel::new(csc.clone());
+            if !self.subchannel_to_policy.contains_key(&key) {
+                // println!("inserting subchannel {} into child_id {}", csc, child);
+                self.subchannel_to_policy.insert(key, child_kind.clone());
+                // }
+            }
+           
+        }
+
+
+
+        // Update the tracked state if the child produced an update.
+        // if let Some(state) = channel_controller.picker_update.clone() {
+        //     self.children.get_mut(&child_id.clone()).unwrap().state = state;
+        //     self.updated = true;
+        // };
+        // // Prune subchannels created by this child that are no longer
+        // // referenced.
+        // self.subchannels.retain(|sc, cid| {
+        //     if cid != &child_id {
+        //         return true;
+        //     }
+        //     if sc.upgrade().is_none() {
+        //         return false;
+        //     }
+        //     true
+        // });
+        // if self.has_updated() {
+        //     self.aggregate_states(channel_controller);
+
+        // }
+        
+
+    }
+
+    fn parse_config(
+        config: &ParsedJsonLbConfig,
+    ) -> Result<Option<LbConfig>, Box<dyn Error + Send + Sync>> {
+        let cfg: GracefulSwitchConfig = match config.convert_to() {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(format!("failed to parse JSON config: {}", e).into());
+            }
+        };
+        for c in &cfg.children_policies {
+            assert!(
+                c.len() == 1,
+                "Each children_policies entry must contain exactly one policy, found {}",
+                c.len()
+            );
+            if let Some((policy_name, policy_config)) = c.iter().next() {
+                if let Some(child) = GLOBAL_LB_REGISTRY.get_policy(policy_name.as_str()) {
+                    let parsed_config = ParsedJsonLbConfig(policy_config.clone());
+                    let config_result = child.parse_config(&parsed_config);
+
+                    let config = match config_result {
+                        Ok(Some(cfg)) => cfg,
+                        Ok(None) => {
+                            if policy_name == "round_robin" {
+                                continue
+                            }
+                            else{
+                                return Err("child policy config returned None".into());
+                            }
+                            
+                        }
+                        Err(e) => {
+                            println!("returning error in parse_config");
+                            return Err(format!("failed to parse child policy config: {}", e).into());
+                        }
+                    };
+
+                    let graceful_switch_lb_config = GracefulSwitchLbConfig::new(child, config);
+                    return Ok(Some(LbConfig::new(Arc::new(graceful_switch_lb_config))))
+                        } else {
+                            continue;
+                        }
+                    } else {
+                        continue;
+                    }
+        }
+        Ok(None)
+    }
+    //how do i set pending child to the child from parse_config?
+
+    fn switch_to (&mut self, 
+        update: ResolverUpdate,
+        config: Option<&LbConfig>){
+        println!("TypeId for GracefulSwitchLbConfig: {:?}", std::any::TypeId::of::<GracefulSwitchLbConfig>());
+        let cfg: Arc<GracefulSwitchLbConfig> = match config.unwrap().convert_to::<Arc<GracefulSwitchLbConfig>>() {
+            Ok(cfg) => (*cfg).clone(),
+            Err(e) => panic!("convert_to failed: {e}"),
+        };
+        let child_builder = cfg.child_builder.clone();
+        let options = LbPolicyOptions { work_scheduler: self.work_scheduler.clone() }; 
+        let pending_policy = child_builder.build(options);
+        if self.current_policy.lock().unwrap().is_none(){
+            *self.current_policy.lock().unwrap() = Some(pending_policy);
+        }
+        else {
+            *self.pending_policy.lock().unwrap() = Some(pending_policy);
+
+        }
+
+    }
+}
+
+
+struct WrappedController<'a> {
+    channel_controller: &'a mut dyn ChannelController,
+    // created_subchannels: Vec<Arc<dyn Subchannel>>,
+    created_subchannels: Vec<Arc<dyn Subchannel>>,
+    //have this be a bool and set true when set to idle
+    picker_update: Option<LbState>,
+}
+
+impl<'a> WrappedController<'a> {
+    fn new(channel_controller: &'a mut dyn ChannelController) -> Self {
+        Self {
+            channel_controller,
+            // subchannel_to_child: HashMap::default(),
+            created_subchannels: vec![],
+            // child_policy: child_policy,
+            picker_update: None, //change into bool
+        }
+    }
+}
+
+impl ChannelController for WrappedController<'_> {
+    //call into the real channel controller
+    fn new_subchannel(&mut self, address: &Address) -> Arc<dyn Subchannel> {
+        let subchannel = self.channel_controller.new_subchannel(address);
+        self.created_subchannels.push(subchannel.clone());
+        subchannel
+    }
+
+    fn update_picker(&mut self, update: LbState) {
+        let update_clone = update.clone();
+        self.channel_controller.update_picker(update);
+        self.picker_update = Some(update_clone);
+    }
+
+    fn request_resolution(&mut self) {
+        // self.channel_controller.request_resolution(update);
+        self.channel_controller.request_resolution();
+    }
+}
+
+// impl<'a> WrappedController<'a> {
+//     fn change_child(&mut self, child_policy: Arc<dyn LbPolicyBuilder>)  {
+//         self.child_policy = child_policy;
+//     }
+// }
+
+

--- a/grpc/src/client/load_balancing/graceful_switch/test.rs
+++ b/grpc/src/client/load_balancing/graceful_switch/test.rs
@@ -10,18 +10,22 @@ use crate::client::{load_balancing::
 impl GracefulSwitchPolicy {
     /// Returns the name of the current policy, if any.
     pub fn current_policy_name(&self) -> Option<String> {
-        self.current_policy_builder
+        self.managing_policy
             .lock()
             .unwrap()
+            .current_child
+            .policy_builder
             .as_ref()
             .map(|b| b.name().to_string())
     }
 
     /// Returns the name of the pending policy, if any.
     pub fn pending_policy_name(&self) -> Option<String> {
-        self.pending_policy_builder
+        self.managing_policy
             .lock()
             .unwrap()
+            .pending_child
+            .policy_builder
             .as_ref()
             .map(|b| b.name().to_string())
     }

--- a/grpc/src/client/load_balancing/graceful_switch/test.rs
+++ b/grpc/src/client/load_balancing/graceful_switch/test.rs
@@ -483,7 +483,7 @@ async fn gracefulswitch_mock_switching_to_resolver_update() {
 
     // Simulate subchannel creation and ready for pending
     let subchannels_two = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-    verify_mock_connecting_picker_from_policy(&mut rx_events).await;
+    // verify_mock_connecting_picker_from_policy(&mut rx_events).await;
     // send_initial_subchannel_updates_to_policy(&mut *graceful_switch, &subchannels_two, tcc.as_mut());
     move_subchannel_to_ready(&mut *graceful_switch, subchannels_two[0].clone(), tcc.as_mut());
 

--- a/grpc/src/client/load_balancing/graceful_switch/test.rs
+++ b/grpc/src/client/load_balancing/graceful_switch/test.rs
@@ -1,0 +1,95 @@
+
+use std::sync::Arc;
+
+use tokio::sync::mpsc;
+
+use crate::client::{load_balancing::{graceful_switch::{self, GracefulSwitchPolicy}, pick_first, round_robin, test_utils::{FakeChannel, TestEvent, TestWorkScheduler}, ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, ParsedJsonLbConfig, GLOBAL_LB_REGISTRY}, name_resolution::{Address, Endpoint, ResolverUpdate}, service_config::ServiceConfig};
+
+
+
+fn setup() -> (
+    mpsc::UnboundedReceiver<TestEvent>,
+    Box<dyn LbPolicy>,
+    // Box<dyn LbPolicy>,
+    // Box<dyn LbPolicy>,
+    Box<dyn ChannelController>,
+) {
+    pick_first::reg();
+    round_robin::reg();
+    
+    let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
+    let work_scheduler = Arc::new(TestWorkScheduler {
+        tx_events: tx_events.clone(),
+    });
+    // let tcc = Box::new(FakeChannel::new(tx_events.clone()));
+    let tcc = Box::new(FakeChannel {
+        tx_events: tx_events.clone(),
+    });
+    // let builder: Arc<dyn LbPolicyBuilder> = GLOBAL_LB_REGISTRY.get_policy("round_robin").unwrap();
+    // let lb_policy = builder.build(LbPolicyOptions { work_scheduler: work_scheduler.clone() });
+    // let second_builder: Arc<dyn LbPolicyBuilder> = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
+    // let second_lb_policy = builder.build(LbPolicyOptions { work_scheduler: work_scheduler.clone() });
+    let graceful_switch = GracefulSwitchPolicy::new(work_scheduler.clone());
+    (rx_events, Box::new(graceful_switch), tcc)
+}
+
+fn create_endpoint_with_one_address(addr: String) -> Endpoint {
+    Endpoint {
+        addresses: vec![Address {
+            address: addr,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+#[test]
+fn gracefulswitch_test_switch_to_new_balancer() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) },
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) }
+        ]
+    });
+    // let service_config = ServiceConfig::from_json(&serde_json::to_value(&service_config).unwrap()).unwrap();
+
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint]),
+        ..Default::default()
+    };
+    graceful_switch
+        .resolver_update(update, Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    
+}
+
+// #[test]
+// fn test_switch_multiple_times() {
+//     let balancer1 = Arc::new(DummyBalancer::new());
+//     let balancer2 = Arc::new(DummyBalancer::new());
+//     let balancer3 = Arc::new(DummyBalancer::new());
+
+//     let mut switch = GracefulSwitch::new(balancer1.clone());
+//     assert!(switch.pick().is_err());
+//     assert!(*balancer1.called.lock().unwrap());
+
+//     switch.switch_to(balancer2.clone());
+//     assert!(switch.pick().is_err());
+//     assert!(*balancer2.called.lock().unwrap());
+
+//     switch.switch_to(balancer3.clone());
+//     assert!(switch.pick().is_err());
+//     assert!(*balancer3.called.lock().unwrap());
+// }
+
+// #[test]
+// fn test_no_switch_uses_initial_balancer() {
+//     let balancer = Arc::new(DummyBalancer::new());
+//     let mut switch = GracefulSwitch::new(balancer.clone());
+//     assert!(switch.pick().is_err());
+//     assert!(*balancer.called.lock().unwrap());
+// }

--- a/grpc/src/client/load_balancing/graceful_switch/test.rs
+++ b/grpc/src/client/load_balancing/graceful_switch/test.rs
@@ -1,21 +1,44 @@
-
-use std::sync::Arc;
+use std::{panic, sync::Arc};
 
 use tokio::sync::mpsc;
 
-use crate::client::{load_balancing::{graceful_switch::{self, GracefulSwitchPolicy}, pick_first, round_robin, test_utils::{FakeChannel, TestEvent, TestWorkScheduler}, ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, ParsedJsonLbConfig, GLOBAL_LB_REGISTRY}, name_resolution::{Address, Endpoint, ResolverUpdate}, service_config::ServiceConfig};
+use crate::client::{load_balancing::
+    {graceful_switch::{self, GracefulSwitchPolicy}, pick_first, round_robin::{self, RoundRobinPicker,}, test_utils::{self, FakeChannel, MockBalancerOne, MockBalancerTwo, MockPickerOne, MockPickerTwo, TestEvent, TestWorkScheduler}, ChannelController, LbPolicy, LbPolicyBuilder, LbPolicyOptions, ParsedJsonLbConfig, PickResult, Picker, Subchannel, SubchannelState, GLOBAL_LB_REGISTRY}, 
+    name_resolution::{Address, Endpoint, ResolverUpdate}, service_config::ServiceConfig, ConnectivityState};
 
 
+impl GracefulSwitchPolicy {
+    /// Returns the name of the current policy, if any.
+    pub fn current_policy_name(&self) -> Option<String> {
+        self.current_policy_builder
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|b| b.name().to_string())
+    }
+
+    /// Returns the name of the pending policy, if any.
+    pub fn pending_policy_name(&self) -> Option<String> {
+        self.pending_policy_builder
+            .lock()
+            .unwrap()
+            .as_ref()
+            .map(|b| b.name().to_string())
+    }
+}
 
 fn setup() -> (
     mpsc::UnboundedReceiver<TestEvent>,
-    Box<dyn LbPolicy>,
+    Box< GracefulSwitchPolicy>,
     // Box<dyn LbPolicy>,
     // Box<dyn LbPolicy>,
     Box<dyn ChannelController>,
 ) {
     pick_first::reg();
+
     round_robin::reg();
+
+    test_utils::reg();
     
     let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
     let work_scheduler = Arc::new(TestWorkScheduler {
@@ -43,8 +66,289 @@ fn create_endpoint_with_one_address(addr: String) -> Endpoint {
     }
 }
 
-#[test]
-fn gracefulswitch_test_switch_to_new_balancer() {
+async fn verify_roundrobin_ready_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) -> Arc<dyn Picker> {
+    println!("verify ready picker");
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            println!("connectivity state for ready picker is {}", update.connectivity_state);
+            assert!(update.connectivity_state == ConnectivityState::Ready);
+            // assert!(update.picker == ReadyPickers);
+            let req = test_utils::new_request();
+            match update.picker.pick(&req) {
+                PickResult::Pick(pick) => {
+                    // println!("selected subchannel is {}", pick.subchannel);
+                    // println!("should've been selected subchannel is {}", subchannel);
+                    assert!(pick.subchannel == subchannel.clone());
+                    update.picker.clone()
+                }
+                other => panic!("unexpected pick result {}", other),
+            }
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the subchannels are created for the given addresses in the
+// given order. Returns the subchannels created.
+async fn verify_subchannel_creation_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    addresses: Vec<Address>,
+) -> Vec<Arc<dyn Subchannel>> {
+    println!("verifying subchannel creation");
+    let mut subchannels = Vec::new();
+    // let mut seen: HashSet<Address> = HashSet::new();
+    for address in addresses {
+        
+        match rx_events.recv().await.unwrap() {
+            TestEvent::NewSubchannel(addr, sc) => {
+                // assert!(addr == address.clone());
+                subchannels.push(sc);
+            }
+            other => panic!("unexpected event {}", other),
+        };
+    }
+    subchannels
+}
+
+// Verifies that the channel moves to READY state with a picker that returns the
+// given subchannel.
+//
+// Returns the picker for tests to make more picks, if required.
+
+//need to update this? only takes care of one subchannel
+async fn verify_mock_policy_one_ready_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) -> Arc<dyn Picker> {
+    println!("verify ready picker");
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Ready);
+            let req = test_utils::new_request();
+            
+            match update.picker.pick(&req) {
+                PickResult::Pick(pick) => {
+                    assert!(pick.subchannel.address().address == "one");
+                    update.picker.clone()
+                }
+                other => panic!("unexpected pick result {}", other),
+            }
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the channel moves to READY state with a picker that returns the
+// given subchannel.
+//
+// Returns the picker for tests to make more picks, if required.
+
+//need to update this? only takes care of one subchannel
+async fn verify_mock_policy_two_ready_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) -> Arc<dyn Picker> {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Ready);
+            let req = test_utils::new_request();
+            
+            match update.picker.pick(&req) {
+                PickResult::Pick(pick) => {
+                    assert!(pick.subchannel.address().address == "two");
+                    update.picker.clone()
+                }
+                other => panic!("unexpected pick result {}", other),
+            }
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that a connection attempt is made to the given subchannel.
+async fn verify_connection_attempt_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) {
+    println!("Verify connection attempt");
+
+    let event = rx_events.recv().await.unwrap();
+    println!("  Subchannel: {}", event);
+    match event {
+    // match rx_events.recv().await.unwrap() {
+        TestEvent::Connect(addr) => {
+            assert!(addr == subchannel.address());
+        }
+        other => panic!("unexpected event {}", other),
+    };
+   
+}
+// Verifies that the channel moves to CONNECTING state with a queuing picker.
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_connecting_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+) -> Arc<dyn Picker> {
+    println!("verify connecting picker");
+    match rx_events.recv().await.unwrap() {
+ 
+        TestEvent::UpdatePicker(update) => {
+            println!("connectivity state is {}", update.connectivity_state);
+            assert!(update.connectivity_state == ConnectivityState::Connecting);
+            let req = test_utils::new_request();
+            assert!(update.picker.pick(&req) == PickResult::Queue);
+            return update.picker.clone();
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the channel moves to CONNECTING state with a queuing picker.
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_mock_connecting_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+) -> Arc<dyn Picker> {
+    println!("verify connecting picker");
+    match rx_events.recv().await.unwrap() {
+ 
+        TestEvent::UpdatePicker(update) => {
+            println!("connectivity state is {}", update.connectivity_state);
+            assert!(update.connectivity_state == ConnectivityState::Connecting);
+            let req = test_utils::new_request();
+            return update.picker.clone();
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+fn move_subchannel_to_idle(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Idle,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn send_initial_subchannel_updates_to_policy(
+    lb_policy: &mut dyn LbPolicy,
+    subchannels: &[Arc<dyn Subchannel>],
+    tcc: &mut dyn ChannelController,
+) {
+    for sc in subchannels {
+        lb_policy.subchannel_update(sc.clone(), &SubchannelState::default(), tcc);
+    }
+}
+
+fn move_subchannel_to_connecting(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Connecting,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn move_subchannel_to_ready(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Ready,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn move_subchannel_to_transient_failure(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    err: &str,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::TransientFailure,
+            last_connection_error: Some(Arc::from(Box::from(err.to_owned()))),
+        },
+        tcc,
+    );
+}
+
+#[tokio::test]
+async fn gracefulswitch_successful_first_update() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) },
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) }
+        ]
+    });
+    
+
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+    let roundrobin_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    assert_eq!(roundrobin_subchannels.len(), 1);
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should still be round_robin after second update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should still be None after second update"
+    );
+}
+
+
+
+//Testing that a pending policy is created
+#[tokio::test]
+async fn gracefulswitch_switching_to_resolver_update() {
     let (mut rx_events, mut graceful_switch, mut tcc) = setup();
     let service_config = serde_json::json!({
         "children_policies": [
@@ -58,38 +362,607 @@ fn gracefulswitch_test_switch_to_new_balancer() {
 
     let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
     let update = ResolverUpdate {
-        endpoints: Ok(vec![endpoint]),
+        endpoints: Ok(vec![endpoint.clone()]),
         ..Default::default()
     };
     graceful_switch
-        .resolver_update(update, Some(&parsed_config), &mut *tcc)
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
         .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    let roundrobin_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(&mut *graceful_switch, &roundrobin_subchannels, tcc.as_mut());
+    move_subchannel_to_ready(&mut *graceful_switch, roundrobin_subchannels[0].clone(), tcc.as_mut());
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+        ]
+    });
+
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("pick_first"),
+        "Pending policy should be None after first update"
+    );
+}
+
+//Testing that a pending policy is created
+#[tokio::test]
+async fn gracefulswitch_mock_switching_to_resolver_update() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+
+    // 1. Start with mock_policy_one as current
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "mock_policy_one": serde_json::json!({}) }
+        ]
+    });
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("mock_policy_one"),
+        "Current policy should be mock_policy_one after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+    
+    // Subchannel creation and ready
+    let subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    verify_mock_connecting_picker_from_policy(&mut rx_events).await;
+    // send_initial_subchannel_updates_to_policy(&mut *graceful_switch, &subchannels, tcc.as_mut());
+    move_subchannel_to_ready(&mut *graceful_switch, subchannels[0].clone(), tcc.as_mut());
+
+    // Assert picker is MockPickerOne by checking subchannel address
+    let picker = verify_mock_policy_one_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    let req = test_utils::new_request();
+    match picker.pick(&req) {
+        PickResult::Pick(pick) => {
+            assert_eq!(pick.subchannel.address().address, "one", "Expected MockPickerOne to pick subchannel with address 'one'");
+        }
+        other => panic!("unexpected pick result"),
+    }
+
+    // 2. Switch to mock_policy_two as pending
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "mock_policy_two": serde_json::json!({}) }
+        ]
+    });
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("mock_policy_one"),
+        "Current policy should still be mock_policy_one before swap"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("mock_policy_two"),
+        "Pending policy should be mock_policy_two after switch"
+    );
+
+    // Simulate subchannel creation and ready for pending
+    let subchannels_two = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    verify_mock_connecting_picker_from_policy(&mut rx_events).await;
+    // send_initial_subchannel_updates_to_policy(&mut *graceful_switch, &subchannels_two, tcc.as_mut());
+    move_subchannel_to_ready(&mut *graceful_switch, subchannels_two[0].clone(), tcc.as_mut());
+
+    // Assert picker is MockPickerTwo by checking subchannel address
+    let picker_two = verify_mock_policy_two_ready_picker_from_policy(&mut rx_events, subchannels_two[0].clone()).await;
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("mock_policy_two"),
+        "Current policy should be mock_policy_two after swap"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after swap"
+    );
+}
+
+#[tokio::test]
+async fn gracefulswitch_two_balancers_same_type() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    let roundrobin_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    move_subchannel_to_ready(&mut *graceful_switch, roundrobin_subchannels[0].clone(), tcc.as_mut());
+
+    let picker = verify_roundrobin_ready_picker_from_policy(&mut rx_events, roundrobin_subchannels[0].clone()).await;
+
+    let service_config2 = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+    let parsed_config2 = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config2)).unwrap().unwrap();
+
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config2), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+}
+
+#[tokio::test]
+async fn gracefulswitch_current_not_ready_pending_update() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+
+    // 1. Initial switch to round_robin (acts as mockBalancerBuilder1)
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+   
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let pickfirst_endpoint = create_endpoint_with_one_address("0.0.0.0.0".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    // Switch to first round_robin (current)
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    
+    let current_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    // 2. Switch to another round_robin (pending)
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+           
+        ]
+    });
+    let pickfirst_update = ResolverUpdate {
+        endpoints: Ok(vec![pickfirst_endpoint.clone()]),
+        ..Default::default()
+    };
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("pick_first"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        None,
+        "Pending policy should be None after first update"
+    );
+    
+ 
+}
+
+#[tokio::test]
+async fn gracefulswitch_subchannel_tracking() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+
+    // 1. Initial switch to round_robin (acts as mockBalancerBuilder1)
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+   
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let pickfirst_endpoint = create_endpoint_with_one_address("0.0.0.0.0".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    // Switch to first round_robin (current)
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    
+    let current_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    move_subchannel_to_ready(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+    verify_roundrobin_ready_picker_from_policy(&mut rx_events, current_subchannels[0].clone()).await;
+
+    // 2. Switch to another round_robin (pending)
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+           
+        ]
+    });
+    let pickfirst_update = ResolverUpdate {
+        endpoints: Ok(vec![pickfirst_endpoint.clone()]),
+        ..Default::default()
+    };
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("pick_first"),
+        "Pending policy should be None after first update"
+    );
+    let pending_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    move_subchannel_to_idle(&mut *graceful_switch, pending_subchannels[0].clone(), tcc.as_mut());
+    move_subchannel_to_connecting(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+}
+
+#[tokio::test]
+async fn gracefulswitch_current_leaving_ready() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+
+    // 1. Initial switch to round_robin (acts as mockBalancerBuilder1)
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+   
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let pickfirst_endpoint = create_endpoint_with_one_address("0.0.0.0.0".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    // Switch to first round_robin (current)
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    
+    let current_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    move_subchannel_to_ready(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+    verify_roundrobin_ready_picker_from_policy(&mut rx_events, current_subchannels[0].clone()).await;
+
+    // 2. Switch to another round_robin (pending)
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+            
+        ]
+    });
+    let pickfirst_update = ResolverUpdate {
+        endpoints: Ok(vec![pickfirst_endpoint.clone()]),
+        ..Default::default()
+    };
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("pick_first"),
+        "Pending policy should be None after first update"
+    );
+    
+    let pending_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(&mut *graceful_switch, &pending_subchannels, tcc.as_mut());
+    verify_connection_attempt_from_policy(&mut rx_events, pending_subchannels[0].clone()).await;
+   
+    move_subchannel_to_connecting(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+ 
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("pick_first"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        None,
+        "Pending policy should be None after first update"
+    );
+    move_subchannel_to_ready(&mut *graceful_switch, pending_subchannels[0].clone(), tcc.as_mut());
+    // let picker = verify_
     
 }
 
-// #[test]
-// fn test_switch_multiple_times() {
-//     let balancer1 = Arc::new(DummyBalancer::new());
-//     let balancer2 = Arc::new(DummyBalancer::new());
-//     let balancer3 = Arc::new(DummyBalancer::new());
+#[tokio::test]
+async fn gracefulswitch_pending_replaced_by_another_pending() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+   
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
 
-//     let mut switch = GracefulSwitch::new(balancer1.clone());
-//     assert!(switch.pick().is_err());
-//     assert!(*balancer1.called.lock().unwrap());
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let pickfirst_endpoint = create_endpoint_with_one_address("0.0.0.0.0".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
 
-//     switch.switch_to(balancer2.clone());
-//     assert!(switch.pick().is_err());
-//     assert!(*balancer2.called.lock().unwrap());
+    // Switch to first round_robin (current)
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
 
-//     switch.switch_to(balancer3.clone());
-//     assert!(switch.pick().is_err());
-//     assert!(*balancer3.called.lock().unwrap());
-// }
+    
+    let current_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    move_subchannel_to_ready(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+    verify_roundrobin_ready_picker_from_policy(&mut rx_events, current_subchannels[0].clone()).await;
 
-// #[test]
-// fn test_no_switch_uses_initial_balancer() {
-//     let balancer = Arc::new(DummyBalancer::new());
-//     let mut switch = GracefulSwitch::new(balancer.clone());
-//     assert!(switch.pick().is_err());
-//     assert!(*balancer.called.lock().unwrap());
-// }
+    // 2. Switch to another round_robin (pending)
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+            
+        ]
+    });
+    let pickfirst_update = ResolverUpdate {
+        endpoints: Ok(vec![pickfirst_endpoint.clone()]),
+        ..Default::default()
+    };
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("pick_first"),
+        "Pending policy should be None after first update"
+    );
+
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "mock_policy_one": serde_json::json!({ "shuffleAddressList": false }) },
+            
+        ]
+    });
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("mock_policy_one"),
+        "Pending policy should be None after first update"
+    );
+}
+
+#[tokio::test]
+async fn gracefulswitch_updating_subchannel_removed_child() {
+    let (mut rx_events, mut graceful_switch, mut tcc) = setup();
+    let service_config = serde_json::json!({
+        "children_policies": [
+            { "round_robin": serde_json::json!({}) }
+        ]
+    });
+   
+    let parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(service_config)).unwrap().unwrap();
+
+    let endpoint = create_endpoint_with_one_address("127.0.0.1:1234".to_string());
+    let pickfirst_endpoint = create_endpoint_with_one_address("0.0.0.0.0".to_string());
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint.clone()]),
+        ..Default::default()
+    };
+
+    // Switch to first round_robin (current)
+    graceful_switch
+        .resolver_update(update.clone(), Some(&parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name(),
+        None,
+        "Pending policy should be None after first update"
+    );
+
+    
+    let current_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+    move_subchannel_to_ready(&mut *graceful_switch, current_subchannels[0].clone(), tcc.as_mut());
+    verify_roundrobin_ready_picker_from_policy(&mut rx_events, current_subchannels[0].clone()).await;
+
+    // 2. Switch to another round_robin (pending)
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "pick_first": serde_json::json!({ "shuffleAddressList": false }) },
+            
+        ]
+    });
+    let pickfirst_update = ResolverUpdate {
+        endpoints: Ok(vec![pickfirst_endpoint.clone()]),
+        ..Default::default()
+    };
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("pick_first"),
+        "Pending policy should be None after first update"
+    );
+    let pick_first_subchannels = verify_subchannel_creation_from_policy(&mut rx_events, pickfirst_endpoint.addresses).await;
+    // send_initial_subchannel_updates_to_policy(&mut *graceful_switch, pick_first_subchannels[0].clone(), tcc.as_mut());
+
+    let new_service_config = serde_json::json!({
+        "children_policies": [
+            { "mock_policy_one": serde_json::json!({ "shuffleAddressList": false }) },
+            
+        ]
+    });
+    let new_parsed_config = GracefulSwitchPolicy::parse_config(&ParsedJsonLbConfig(new_service_config)).unwrap().unwrap();
+    graceful_switch
+        .resolver_update(pickfirst_update.clone(), Some(&new_parsed_config), &mut *tcc)
+        .unwrap();
+    assert_eq!(
+        graceful_switch.current_policy_name().as_deref(),
+        Some("round_robin"),
+        "Current policy should be round_robin after first update"
+    );
+    assert_eq!(
+        graceful_switch.pending_policy_name().as_deref(),
+        Some("mock_policy_one"),
+        "Pending policy should be None after first update"
+    );
+    move_subchannel_to_ready(&mut *graceful_switch, pick_first_subchannels[0].clone(), tcc.as_mut());
+    // let result = panic::catch_unwind(|| {
+    //     move_subchannel_to_ready(&mut *graceful_switch, subchannel.clone(), tcc.as_mut());
+    // });
+
+    // assert!(result.is_err(), "Expected panic when moving subchannel to ready, but it did not panic");
+}

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -47,6 +47,8 @@ use crate::client::{
 
 pub mod child_manager;
 pub mod pick_first;
+pub mod round_robin;
+
 
 #[cfg(test)]
 pub mod test_utils;
@@ -147,6 +149,9 @@ pub trait LbPolicy: Send {
     /// Called by the channel in response to a call from the LB policy to the
     /// WorkScheduler's request_work method.
     fn work(&mut self, channel_controller: &mut dyn ChannelController);
+
+    /// Called by pickfirst whenever the LB policy is idle and wants to reconnect
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController);
 }
 
 /// Controls channel behaviors.

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -429,8 +429,10 @@ impl Hash for WeakSubchannel {
 
 impl PartialEq for WeakSubchannel {
     fn eq(&self, other: &Self) -> bool {
-        if let Some(strong) = self.upgrade() {
-            return strong.dyn_eq(&Box::new(other as &dyn Any));
+        if let Some(strong_self) = self.upgrade() {
+            if let Some(strong_other) = other.upgrade() {
+                return strong_self.dyn_eq(&Box::new(&strong_other as &dyn Any));
+            }
         }
         false
     }

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -221,15 +221,17 @@ impl LbPolicy for PickFirstPolicy {
         // Build a new subchannel list with the most recent addresses received
         // from the name resolver. This will start connecting from the first
         // address in the list.
+
+        //can only do meaningful when it has channel controller
+        //called when lb policy has work to do, anything the lb policy wants to do that
         self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
     }
-
     fn exit_idle(& mut self, channel_controller: &mut dyn ChannelController) {
         if self.connectivity_state == ConnectivityState::Idle {
             self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
             self.move_to_connecting(channel_controller);
             if let Some(subchannel_list) = self.subchannel_list.as_mut() {
-                let connected = subchannel_list.connect_to_next_subchannel(channel_controller);
+                let _ = subchannel_list.connect_to_next_subchannel(channel_controller);
             }
         }
     }
@@ -411,6 +413,7 @@ impl PickFirstPolicy {
     }
 
     fn move_to_connecting(&mut self, channel_controller: &mut dyn ChannelController) {
+        println!("state is connecting");
         self.connectivity_state = ConnectivityState::Connecting;
         channel_controller.update_picker(LbState {
             connectivity_state: ConnectivityState::Connecting,
@@ -476,7 +479,6 @@ impl Picker for IdlePicker {
     }
 }
 
-//list of subchannels that pick_first is currently connecting too
 struct SubchannelList {
     subchannels: HashMap<Arc<dyn Subchannel>, SubchannelData>,
     ordered_subchannels: Vec<Arc<dyn Subchannel>>,

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -260,11 +260,21 @@ impl PickFirstPolicy {
         endpoints: &mut [Endpoint],
     ) -> Option<Box<dyn Error + Send + Sync>> {
         config?;
+        // if config.is_none(){
+        //     println!("is not none");
+        //     return None
+        // }
 
+        println!("why are we here");
         let cfg: Arc<PickFirstConfig> = match config.unwrap().convert_to() {
             Ok(cfg) => cfg,
             Err(e) => return Some(e),
         };
+        println!("received update from resolver with config: {:?}", &cfg);
+        // let cfg: Arc<PickFirstConfig> = match config.unwrap().convert_to() {
+        //     Ok(cfg) => cfg,
+        //     Err(e) => return None,
+        // };
         println!("received update from resolver with config: {:?}", &cfg);
 
         let mut shuffle_addresses = false;

--- a/grpc/src/client/load_balancing/pick_first/test.rs
+++ b/grpc/src/client/load_balancing/pick_first/test.rs
@@ -1,0 +1,1213 @@
+// use crate::client::{
+//     load_balancing::{
+//         pick_first::{
+//             self, thread_rng_shuffler, EndpointShuffler, PickFirstConfig, SHUFFLE_ENDPOINTS_FN,
+//         },
+//         test_utils::{self, FakeChannel, TestEvent, TestWorkScheduler},
+//         ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+//         LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+//         Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
+//     },
+//     name_resolution::{Address, Endpoint, ResolverUpdate},
+//     transport::{Transport, GLOBAL_TRANSPORT_REGISTRY},
+//     ConnectivityState,
+// };
+// use crate::service::{Message, Request, Response, Service};
+// use core::panic;
+// use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+// use serde_json::json;
+// use std::{
+//     ops::Add,
+//     sync::{Arc, Mutex},
+// };
+// use tokio::{
+//     sync::{mpsc, Notify},
+//     task::AbortHandle,
+// };
+// use tonic::async_trait;
+
+// #[test]
+// fn pickfirst_builder_name() -> Result<(), String> {
+//     pick_first::reg();
+
+//     let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
+//         Some(b) => b,
+//         None => {
+//             return Err(String::from("pick_first LB policy not registered"));
+//         }
+//     };
+//     assert_eq!(builder.name(), "pick_first");
+//     Ok(())
+// }
+
+// #[test]
+// fn pickfirst_builder_parse_config_failure() -> Result<(), String> {
+//     pick_first::reg();
+
+//     let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
+//         Some(b) => b,
+//         None => {
+//             return Err(String::from("pick_first LB policy not registered"));
+//         }
+//     };
+
+//     // Success cases.
+//     struct TestCase {
+//         config: ParsedJsonLbConfig,
+//         want_shuffle_addresses: Option<bool>,
+//     }
+//     let test_cases = vec![
+//         TestCase {
+//             config: ParsedJsonLbConfig(json!({})),
+//             want_shuffle_addresses: None,
+//         },
+//         TestCase {
+//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": false})),
+//             want_shuffle_addresses: Some(false),
+//         },
+//         TestCase {
+//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": true})),
+//             want_shuffle_addresses: Some(true),
+//         },
+//         TestCase {
+//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": true, "unknownField": "foo"})),
+//             want_shuffle_addresses: Some(true),
+//         },
+//     ];
+//     for tc in test_cases {
+//         let config = match builder.parse_config(&tc.config) {
+//             Ok(c) => c,
+//             Err(e) => {
+//                 let err = format!(
+//                     "parse_config({:?}) failed when expected to succeed: {:?}",
+//                     tc.config, e
+//                 )
+//                 .clone();
+//                 panic!("{}", err);
+//             }
+//         };
+//         let config: LbConfig = match config {
+//             Some(c) => c,
+//             None => {
+//                 let err = format!(
+//                     "parse_config({:?}) returned None when expected to succeed",
+//                     tc.config
+//                 )
+//                 .clone();
+//                 panic!("{}", err);
+//             }
+//         };
+//         let got_config: Arc<PickFirstConfig> = config.convert_to().unwrap();
+//         assert!(got_config.shuffle_address_list == tc.want_shuffle_addresses);
+//     }
+//     Ok(())
+// }
+
+// // Sets up the test environment.
+// //
+// // Performs the following:
+// // 1. Creates a work scheduler.
+// // 2. Creates a fake channel that acts as a channel controller.
+// // 3. Creates a pick_first LB policy.
+// //
+// // Returns the following:
+// // 1. A receiver for events initiated by the LB policy (like creating a
+// //    new subchannel, sending a new picker etc).
+// // 2. The LB policy to send resolver and subchannel updates from the test.
+// // 3. The channel to pass to the LB policy as part of the updates.
+// fn setup() -> (
+//     mpsc::UnboundedReceiver<TestEvent>,
+//     Box<dyn LbPolicy>,
+//     Box<dyn ChannelController>,
+// ) {
+//     pick_first::reg();
+//     let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
+//     let work_scheduler = Arc::new(TestWorkScheduler {
+//         tx_events: tx_events.clone(),
+//     });
+//     let tcc = Box::new(FakeChannel {
+//         tx_events: tx_events.clone(),
+//     });
+//     let builder: Arc<dyn LbPolicyBuilder> = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
+//     let lb_policy = builder.build(LbPolicyOptions { work_scheduler });
+
+//     (rx_events, lb_policy, tcc)
+// }
+
+// fn create_endpoint_with_one_address(addr: String) -> Endpoint {
+//     Endpoint {
+//         addresses: vec![Address {
+//             address: addr,
+//             ..Default::default()
+//         }],
+//         ..Default::default()
+//     }
+// }
+
+// // Creates a new endpoint with the specified number of addresses.
+// fn create_endpoint_with_n_addresses(n: usize) -> Endpoint {
+//     let mut addresses = Vec::new();
+//     for i in 0..n {
+//         addresses.push(Address {
+//             address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
+//             ..Default::default()
+//         });
+//     }
+//     Endpoint {
+//         addresses,
+//         ..Default::default()
+//     }
+// }
+
+// // Sends a resolver update to the LB policy with the specified endpoint.
+// fn send_resolver_update_to_policy(
+//     lb_policy: &mut dyn LbPolicy,
+//     endpoints: Vec<Endpoint>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     let update = ResolverUpdate {
+//         endpoints: Ok(endpoints.clone()),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
+// }
+
+// // Sends a resolver update with LB config enabling address shuffling to the LB
+// // policy with the specified endpoint.
+// fn send_resolver_update_with_lb_config_to_policy(
+//     lb_policy: &mut dyn LbPolicy,
+//     endpoints: Vec<Endpoint>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     let update = ResolverUpdate {
+//         endpoints: Ok(endpoints.clone()),
+//         ..Default::default()
+//     };
+
+//     let json_config = ParsedJsonLbConfig(json!({"shuffleAddressList": true}));
+//     let builder = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
+//     let config = builder.parse_config(&json_config).unwrap();
+
+//     assert!(lb_policy
+//         .resolver_update(update, config.as_ref(), tcc)
+//         .is_ok());
+// }
+
+// // Sends a resolver error to the LB policy with the specified error message.
+// fn send_resolver_error_to_policy(
+//     lb_policy: &mut dyn LbPolicy,
+//     err: String,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     let update = ResolverUpdate {
+//         endpoints: Err(err),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
+// }
+
+// // Verifies that the subchannels are created for the given addresses in the
+// // given order. Returns the subchannels created.
+// async fn verify_subchannel_creation_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     addresses: Vec<Address>,
+// ) -> Vec<Arc<dyn Subchannel>> {
+//     let mut subchannels = Vec::new();
+//     for address in addresses {
+//         match rx_events.recv().await.unwrap() {
+//             TestEvent::NewSubchannel(addr, sc) => {
+//                 assert!(addr == address.clone());
+//                 subchannels.push(sc);
+//             }
+//             other => panic!("unexpected event {}", other),
+//         };
+//     }
+//     subchannels
+// }
+
+// // Sends initial subchannel updates to the LB policy for the given
+// // subchannels, with their state set to IDLE.
+// fn send_initial_subchannel_updates_to_policy(
+//     lb_policy: &mut dyn LbPolicy,
+//     subchannels: &[Arc<dyn Subchannel>],
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     for sc in subchannels {
+//         lb_policy.subchannel_update(sc.clone(), &SubchannelState::default(), tcc);
+//     }
+// }
+
+// fn move_subchannel_to_idle(
+//     lb_policy: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     lb_policy.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Idle,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_connecting(
+//     lb_policy: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     lb_policy.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Connecting,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_ready(
+//     lb_policy: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     lb_policy.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+// }
+
+// fn move_subchannel_to_transient_failure(
+//     lb_policy: &mut dyn LbPolicy,
+//     subchannel: Arc<dyn Subchannel>,
+//     err: &str,
+//     tcc: &mut dyn ChannelController,
+// ) {
+//     lb_policy.subchannel_update(
+//         subchannel.clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::TransientFailure,
+//             last_connection_error: Some(Arc::from(Box::from(err.to_owned()))),
+//         },
+//         tcc,
+//     );
+// }
+
+// // Verifies that a connection attempt is made to the given subchannel.
+// async fn verify_connection_attempt_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     subchannel: Arc<dyn Subchannel>,
+// ) {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::Connect(addr) => {
+//             assert!(addr == subchannel.address());
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// // Verifies that a call to schedule_work is made by the LB policy.
+// async fn verify_schedule_work_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::ScheduleWork => {}
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// // Verifies that the channel moves to IDLE state.
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_idle_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+// ) -> Arc<dyn Picker> {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::Idle);
+//             update.picker.clone()
+//         }
+//         other => panic!("unexpected event {}", other),
+//     }
+// }
+
+// // Verifies that the channel moves to CONNECTING state with a queuing picker.
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_connecting_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+// ) -> Arc<dyn Picker> {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::Connecting);
+//             let req = test_utils::new_request();
+//             assert!(update.picker.pick(&req) == PickResult::Queue);
+//             update.picker.clone()
+//         }
+//         other => panic!("unexpected event {}", other),
+//     }
+// }
+
+// // Verifies that the channel moves to READY state with a picker that returns the
+// // given subchannel.
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_ready_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     subchannel: Arc<dyn Subchannel>,
+// ) -> Arc<dyn Picker> {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::Ready);
+//             let req = test_utils::new_request();
+//             match update.picker.pick(&req) {
+//                 PickResult::Pick(pick) => {
+//                     assert!(pick.subchannel == subchannel.clone());
+//                     update.picker.clone()
+//                 }
+//                 other => panic!("unexpected pick result {}", other),
+//             }
+//         }
+//         other => panic!("unexpected event {}", other),
+//     }
+// }
+
+// // Verifies that the channel moves to TRANSIENT_FAILURE state with a picker
+// // that returns an error with the given message. The error code should be
+// // UNAVAILABLE..
+// //
+// // Returns the picker for tests to make more picks, if required.
+// async fn verify_transient_failure_picker_from_policy(
+//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+//     want_error: String,
+// ) -> Arc<dyn Picker> {
+//     let picker = match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::TransientFailure);
+//             let req = test_utils::new_request();
+//             match update.picker.pick(&req) {
+//                 PickResult::Fail(status) => {
+//                     assert!(status.code() == tonic::Code::Unavailable);
+//                     assert!(status.message().contains(&want_error));
+//                     update.picker.clone()
+//                 }
+//                 other => panic!("unexpected pick result {}", other),
+//             }
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::RequestResolution => {}
+//         _ => panic!("no re-resolution requested after moving to transient_failure"),
+//     }
+//     picker
+// }
+
+// // Verifies that the channel moves to IDLE state.
+// async fn verify_channel_moves_to_idle(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::UpdatePicker(update) => {
+//             assert!(update.connectivity_state == ConnectivityState::Idle);
+//         }
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// // Verifies that the LB policy requests re-resolution.
+// async fn verify_resolution_request(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     match rx_events.recv().await.unwrap() {
+//         TestEvent::RequestResolution => {}
+//         other => panic!("unexpected event {}", other),
+//     };
+// }
+
+// const DEFAULT_TEST_SHORT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+// async fn verify_no_activity_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+//     tokio::select! {
+//         _ = tokio::time::sleep(DEFAULT_TEST_SHORT_TIMEOUT) => {}
+//         event = rx_events.recv() => {
+//             panic!("unexpected event {}", event.unwrap());
+//         }
+//     }
+// }
+
+// // Tests the scenario where the resolver returns an error before a valid update.
+// // The LB policy should move to TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_resolver_error_before_a_valid_update() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+// }
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy has moved to READY. The LB policy should ignore the error
+// // and continue using the previously received update.
+// #[tokio::test]
+// async fn pickfirst_resolver_error_after_a_valid_update_in_ready() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+//     let picker = verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+//     verify_no_activity_from_policy(&mut rx_events).await;
+
+//     let req = test_utils::new_request();
+//     match picker.pick(&req) {
+//         PickResult::Pick(pick) => {
+//             assert!(pick.subchannel == subchannels[0].clone());
+//         }
+//         other => panic!("unexpected pick result {}", other),
+//     }
+// }
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy is still trying to connect. The LB policy should ignore the
+// // error and continue using the previously received update.
+// #[tokio::test]
+// async fn pickfirst_resolver_error_after_a_valid_update_in_connecting() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     let picker = verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+//     verify_no_activity_from_policy(&mut rx_events).await;
+
+//     let req = test_utils::new_request();
+//     match picker.pick(&req) {
+//         PickResult::Queue => {}
+//         other => panic!("unexpected pick result {}", other),
+//     }
+// }
+
+// // Tests the scenario where the resolver returns an error after a valid update
+// // and the LB policy has moved to TRANSIENT_FAILURE after attemting to connect
+// // to all addresses.  The LB policy should send a new picker that returns the
+// // error from the resolver.
+// #[tokio::test]
+// async fn pickfirst_resolver_error_after_a_valid_update_in_tf() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     let connection_error = String::from("test connection error");
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
+
+//     let resolver_error = String::from("resolver error");
+//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with no addresses
+// // (before sending any valid update). The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_zero_addresses_from_resolver_before_valid_update() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(0);
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![endpoint]),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with no endpoints
+// // (before sending any valid update). The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_zero_endpoints_from_resolver_before_valid_update() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![]),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with no endpoints
+// // after sending a valid update (and the LB policy has moved to READY). The LB
+// // policy should move to TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_zero_endpoints_from_resolver_after_valid_update() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![]),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with one address. The
+// // LB policy should create a subchannel for that address, connect to it, and
+// // once the connection succeeds, move to READY state with a picker that returns
+// // that subchannel.
+// #[tokio::test]
+// async fn pickfirst_with_one_backend() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(1);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // address. The LB policy should create subchannels for all address, and attempt
+// // to connect to them in order, until a connection succeeds, at which point it
+// // should move to READY state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn pickfirst_with_multiple_backends_first_backend_is_ready() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // address. The LB policy should create subchannels for all address, and attempt
+// // to connect to them in order, until a connection succeeds, at which point it
+// // should move to READY state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn pickfirst_with_multiple_backends_first_backend_is_not_ready() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(3);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     let connection_error = String::from("test connection error");
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[2].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[2].clone(), tcc);
+//     move_subchannel_to_ready(lb_policy, subchannels[2].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[2].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // address, some of which are duplicates. The LB policy should dedup the
+// // addresses and create subchannels for them, and attempt to connect to them in
+// // order, until a connection succeeds, at which point it should move to READY
+// // state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn pickfirst_with_multiple_backends_duplicate_addresses() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = Endpoint {
+//         addresses: vec![
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+//                 ..Default::default()
+//             },
+//         ],
+//         ..Default::default()
+//     };
+//     let endpoint_with_duplicates_removed = Endpoint {
+//         addresses: vec![
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+//                 ..Default::default()
+//             },
+//             Address {
+//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+//                 ..Default::default()
+//             },
+//         ],
+//         ..Default::default()
+//     };
+
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels = verify_subchannel_creation_from_policy(
+//         &mut rx_events,
+//         endpoint_with_duplicates_removed.addresses.clone(),
+//     )
+//     .await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     let connection_error = String::from("test connection error");
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and connections to all of them fail. The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker. It should then attempt to connect
+// // to the addresses again, and when they fail again, it should send a new
+// // picker that returns the most recent error message.
+// #[tokio::test]
+// async fn pickfirst_sticky_transient_failure() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoint = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     let first_error = String::from("test connection error 1");
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &first_error, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &first_error, tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, first_error).await;
+
+//     // The subchannels need to complete their backoff before moving to IDLE, at
+//     // which point the LB policy should attempt to connect to them again.
+//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+//     move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+
+//     let second_error = String::from("test connection error 2");
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &second_error, tcc);
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &second_error, tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, second_error).await;
+
+//     // The subchannels need to complete their backoff before moving to IDLE, at
+//     // which point the LB policy should attempt to connect to them again.
+//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+//     move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Overrides the default shuffler function with a custom one that reverses the
+// // order of the endpoints.
+// fn test_reverse_shuffler() -> Box<EndpointShuffler> {
+//     Box::new(|endpoints: &mut [Endpoint]| {
+//         endpoints.reverse();
+//     })
+// }
+
+// // Resets the shuffler function to the default one after the test completes
+// struct ShufflerResetGuard {}
+// impl Drop for ShufflerResetGuard {
+//     fn drop(&mut self) {
+//         *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = thread_rng_shuffler();
+//     }
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // endpoints and LB config with shuffle addresses enabled. We override the
+// // shuffler functionality to reverse the order of the endpoints. The LB policy
+// // should create subchannels for all addresses, and attempt to connect to them
+// // in order, until a connection succeeds, at which point it should move to READY
+// // state with a picker that returns that subchannel.
+// #[tokio::test]
+// async fn pickfirst_with_multiple_backends_shuffle_addresses() {
+//     let _guard = ShufflerResetGuard {};
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+//     *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = test_reverse_shuffler();
+
+//     let endpoint1 = create_endpoint_with_one_address("1.1.1.1:1".to_string());
+//     let endpoint2 = create_endpoint_with_one_address("2.2.2.2:2".to_string());
+//     send_resolver_update_with_lb_config_to_policy(
+//         lb_policy,
+//         vec![endpoint1.clone(), endpoint2.clone()],
+//         tcc,
+//     );
+
+//     let subchannels = verify_subchannel_creation_from_policy(
+//         &mut rx_events,
+//         endpoint2
+//             .addresses
+//             .clone()
+//             .into_iter()
+//             .chain(endpoint1.addresses.iter().cloned())
+//             .collect(),
+//     )
+//     .await;
+
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a new address list that does
+// // not contain the address of the currently connected subchannel. The LB policy
+// // should create subchannels for the new addresses, and then realize that the
+// // currently connected subchannel is not in the new address list. It should then
+// // move to IDLE state and return a picker that queues RPCs. When an RPC is made,
+// // the LB policy should create subchannels for the addresses specified in the
+// // previous update and start connecting to them.
+// #[tokio::test]
+// async fn pickfirst_resolver_update_with_completely_new_address_list() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let endpoints = create_endpoint_with_one_address("3.3.3.3:3".to_string());
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+//     verify_resolution_request(&mut rx_events).await;
+//     let req = test_utils::new_request();
+//     assert!(picker.pick(&req) == PickResult::Queue);
+//     verify_schedule_work_from_policy(&mut rx_events).await;
+//     lb_policy.work(tcc);
+
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a new address list that
+// // contains the address of the currently connected subchannel. The LB policy
+// // should create subchannels for the new addresses, and then see that the
+// // currently connected subchannel is in the new address list. It should then
+// // send a new READY picker that returns the currently connected subchannel.
+// #[tokio::test]
+// async fn pickfirst_resolver_update_contains_currently_ready_subchannel() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     let mut endpoints = create_endpoint_with_n_addresses(4);
+//     endpoints.addresses.reverse();
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     lb_policy.subchannel_update(subchannels[0].clone(), &SubchannelState::default(), tcc);
+//     lb_policy.subchannel_update(subchannels[1].clone(), &SubchannelState::default(), tcc);
+//     lb_policy.subchannel_update(subchannels[2].clone(), &SubchannelState::default(), tcc);
+//     lb_policy.subchannel_update(
+//         subchannels[3].clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[3].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a an address list that is
+// // identical to the first update. The LB policy should create subchannels for
+// // the new addresses, and then see that the currently connected subchannel is in
+// // the new address list. It should then send a new READY picker that returns the
+// // currently connected subchannel.
+// #[tokio::test]
+// async fn pickfirst_resolver_update_contains_identical_address_list() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     lb_policy.subchannel_update(
+//         subchannels[0].clone(),
+//         &SubchannelState {
+//             connectivity_state: ConnectivityState::Ready,
+//             ..Default::default()
+//         },
+//         tcc,
+//     );
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The resolver then returns an update with a new address list that
+// // removes the address of the currently connected subchannel. The LB policy
+// // should create subchannels for the new addresses, and then see that the
+// // currently connected subchannel is not in the new address list. It should then
+// // move to IDLE state and return a picker that queues RPCs. When an RPC is made,
+// // the LB policy should create subchannels for the addresses specified in the
+// // previous update and start connecting to them. The test repeats this scenario
+// // multiple times, each time removing the first address from the address list,
+// // eventually ending up with an empty address list. The LB policy should move to
+// // TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_resolver_update_removes_connected_address() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let mut endpoints = create_endpoint_with_n_addresses(3);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     // Address list now contains two addresses.
+//     endpoints.addresses.remove(0);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+//     verify_resolution_request(&mut rx_events).await;
+//     let req = test_utils::new_request();
+//     assert!(picker.pick(&req) == PickResult::Queue);
+//     verify_schedule_work_from_policy(&mut rx_events).await;
+//     lb_policy.work(tcc);
+
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     // Address list now contains one address.
+//     endpoints.addresses.remove(0);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+//     verify_resolution_request(&mut rx_events).await;
+//     let req = test_utils::new_request();
+//     assert!(picker.pick(&req) == PickResult::Queue);
+//     verify_schedule_work_from_policy(&mut rx_events).await;
+//     lb_policy.work(tcc);
+
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     // Address list is now empty.
+//     endpoints.addresses.remove(0);
+//     let update = ResolverUpdate {
+//         endpoints: Ok(vec![endpoints]),
+//         ..Default::default()
+//     };
+//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+//     verify_transient_failure_picker_from_policy(
+//         &mut rx_events,
+//         "received empty address list from the name resolver".to_string(),
+//     )
+//     .await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The connected subchannel then goes down and the LB policy moves to IDLE
+// // state with a picker that queues RPCs. When an RPC is made, the LB policy
+// // creates subchannels for the addresses specified in the previous update and
+// // starts connecting to them. The LB policy should then move to READY state with
+// // a picker that returns the second subchannel.
+// #[tokio::test]
+// async fn pickfirst_connected_subchannel_goes_down() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+//     verify_resolution_request(&mut rx_events).await;
+//     let req = test_utils::new_request();
+//     assert!(picker.pick(&req) == PickResult::Queue);
+//     verify_schedule_work_from_policy(&mut rx_events).await;
+//     lb_policy.work(tcc);
+
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(
+//         lb_policy,
+//         subchannels[0].clone(),
+//         "connection error",
+//         tcc,
+//     );
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
+// }
+
+// // Tests the scenario where the resolver returns an update with multiple
+// // addresses and the LB policy successfully connects to first one and moves to
+// // READY. The connected subchannel then goes down and the LB policy moves to IDLE
+// // state with a picker that queues RPCs. When an RPC is made, the LB policy
+// // creates subchannels for the addresses specified in the previous update and
+// // starts connecting to them. All subchannels fail to connect and the LB policy
+// // moves to TRANSIENT_FAILURE state with a failing picker.
+// #[tokio::test]
+// async fn pickfirst_all_subchannels_goes_down() {
+//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
+//     let lb_policy = lb_policy.as_mut();
+//     let tcc = tcc.as_mut();
+
+//     let endpoints = create_endpoint_with_n_addresses(2);
+//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+//     verify_resolution_request(&mut rx_events).await;
+//     let req = test_utils::new_request();
+//     assert!(picker.pick(&req) == PickResult::Queue);
+//     verify_schedule_work_from_policy(&mut rx_events).await;
+//     lb_policy.work(tcc);
+
+//     let connection_error = String::from("test connection error 2");
+//     let subchannels =
+//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+//     verify_connecting_picker_from_policy(&mut rx_events).await;
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+//     verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
+// }

--- a/grpc/src/client/load_balancing/pick_first/test.rs
+++ b/grpc/src/client/load_balancing/pick_first/test.rs
@@ -1,1213 +1,1217 @@
-// use crate::client::{
-//     load_balancing::{
-//         pick_first::{
-//             self, thread_rng_shuffler, EndpointShuffler, PickFirstConfig, SHUFFLE_ENDPOINTS_FN,
-//         },
-//         test_utils::{self, FakeChannel, TestEvent, TestWorkScheduler},
-//         ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
-//         LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
-//         Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
-//     },
-//     name_resolution::{Address, Endpoint, ResolverUpdate},
-//     transport::{Transport, GLOBAL_TRANSPORT_REGISTRY},
-//     ConnectivityState,
-// };
-// use crate::service::{Message, Request, Response, Service};
-// use core::panic;
-// use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
-// use serde_json::json;
-// use std::{
-//     ops::Add,
-//     sync::{Arc, Mutex},
-// };
-// use tokio::{
-//     sync::{mpsc, Notify},
-//     task::AbortHandle,
-// };
-// use tonic::async_trait;
-
-// #[test]
-// fn pickfirst_builder_name() -> Result<(), String> {
-//     pick_first::reg();
-
-//     let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
-//         Some(b) => b,
-//         None => {
-//             return Err(String::from("pick_first LB policy not registered"));
-//         }
-//     };
-//     assert_eq!(builder.name(), "pick_first");
-//     Ok(())
-// }
-
-// #[test]
-// fn pickfirst_builder_parse_config_failure() -> Result<(), String> {
-//     pick_first::reg();
-
-//     let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
-//         Some(b) => b,
-//         None => {
-//             return Err(String::from("pick_first LB policy not registered"));
-//         }
-//     };
-
-//     // Success cases.
-//     struct TestCase {
-//         config: ParsedJsonLbConfig,
-//         want_shuffle_addresses: Option<bool>,
-//     }
-//     let test_cases = vec![
-//         TestCase {
-//             config: ParsedJsonLbConfig(json!({})),
-//             want_shuffle_addresses: None,
-//         },
-//         TestCase {
-//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": false})),
-//             want_shuffle_addresses: Some(false),
-//         },
-//         TestCase {
-//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": true})),
-//             want_shuffle_addresses: Some(true),
-//         },
-//         TestCase {
-//             config: ParsedJsonLbConfig(json!({"shuffleAddressList": true, "unknownField": "foo"})),
-//             want_shuffle_addresses: Some(true),
-//         },
-//     ];
-//     for tc in test_cases {
-//         let config = match builder.parse_config(&tc.config) {
-//             Ok(c) => c,
-//             Err(e) => {
-//                 let err = format!(
-//                     "parse_config({:?}) failed when expected to succeed: {:?}",
-//                     tc.config, e
-//                 )
-//                 .clone();
-//                 panic!("{}", err);
-//             }
-//         };
-//         let config: LbConfig = match config {
-//             Some(c) => c,
-//             None => {
-//                 let err = format!(
-//                     "parse_config({:?}) returned None when expected to succeed",
-//                     tc.config
-//                 )
-//                 .clone();
-//                 panic!("{}", err);
-//             }
-//         };
-//         let got_config: Arc<PickFirstConfig> = config.convert_to().unwrap();
-//         assert!(got_config.shuffle_address_list == tc.want_shuffle_addresses);
-//     }
-//     Ok(())
-// }
-
-// // Sets up the test environment.
-// //
-// // Performs the following:
-// // 1. Creates a work scheduler.
-// // 2. Creates a fake channel that acts as a channel controller.
-// // 3. Creates a pick_first LB policy.
-// //
-// // Returns the following:
-// // 1. A receiver for events initiated by the LB policy (like creating a
-// //    new subchannel, sending a new picker etc).
-// // 2. The LB policy to send resolver and subchannel updates from the test.
-// // 3. The channel to pass to the LB policy as part of the updates.
-// fn setup() -> (
-//     mpsc::UnboundedReceiver<TestEvent>,
-//     Box<dyn LbPolicy>,
-//     Box<dyn ChannelController>,
-// ) {
-//     pick_first::reg();
-//     let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
-//     let work_scheduler = Arc::new(TestWorkScheduler {
-//         tx_events: tx_events.clone(),
-//     });
-//     let tcc = Box::new(FakeChannel {
-//         tx_events: tx_events.clone(),
-//     });
-//     let builder: Arc<dyn LbPolicyBuilder> = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
-//     let lb_policy = builder.build(LbPolicyOptions { work_scheduler });
-
-//     (rx_events, lb_policy, tcc)
-// }
-
-// fn create_endpoint_with_one_address(addr: String) -> Endpoint {
-//     Endpoint {
-//         addresses: vec![Address {
-//             address: addr,
-//             ..Default::default()
-//         }],
-//         ..Default::default()
-//     }
-// }
-
-// // Creates a new endpoint with the specified number of addresses.
-// fn create_endpoint_with_n_addresses(n: usize) -> Endpoint {
-//     let mut addresses = Vec::new();
-//     for i in 0..n {
-//         addresses.push(Address {
-//             address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
-//             ..Default::default()
-//         });
-//     }
-//     Endpoint {
-//         addresses,
-//         ..Default::default()
-//     }
-// }
-
-// // Sends a resolver update to the LB policy with the specified endpoint.
-// fn send_resolver_update_to_policy(
-//     lb_policy: &mut dyn LbPolicy,
-//     endpoints: Vec<Endpoint>,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     let update = ResolverUpdate {
-//         endpoints: Ok(endpoints.clone()),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
-// }
-
-// // Sends a resolver update with LB config enabling address shuffling to the LB
-// // policy with the specified endpoint.
-// fn send_resolver_update_with_lb_config_to_policy(
-//     lb_policy: &mut dyn LbPolicy,
-//     endpoints: Vec<Endpoint>,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     let update = ResolverUpdate {
-//         endpoints: Ok(endpoints.clone()),
-//         ..Default::default()
-//     };
-
-//     let json_config = ParsedJsonLbConfig(json!({"shuffleAddressList": true}));
-//     let builder = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
-//     let config = builder.parse_config(&json_config).unwrap();
-
-//     assert!(lb_policy
-//         .resolver_update(update, config.as_ref(), tcc)
-//         .is_ok());
-// }
-
-// // Sends a resolver error to the LB policy with the specified error message.
-// fn send_resolver_error_to_policy(
-//     lb_policy: &mut dyn LbPolicy,
-//     err: String,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     let update = ResolverUpdate {
-//         endpoints: Err(err),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
-// }
-
-// // Verifies that the subchannels are created for the given addresses in the
-// // given order. Returns the subchannels created.
-// async fn verify_subchannel_creation_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-//     addresses: Vec<Address>,
-// ) -> Vec<Arc<dyn Subchannel>> {
-//     let mut subchannels = Vec::new();
-//     for address in addresses {
-//         match rx_events.recv().await.unwrap() {
-//             TestEvent::NewSubchannel(addr, sc) => {
-//                 assert!(addr == address.clone());
-//                 subchannels.push(sc);
-//             }
-//             other => panic!("unexpected event {}", other),
-//         };
-//     }
-//     subchannels
-// }
-
-// // Sends initial subchannel updates to the LB policy for the given
-// // subchannels, with their state set to IDLE.
-// fn send_initial_subchannel_updates_to_policy(
-//     lb_policy: &mut dyn LbPolicy,
-//     subchannels: &[Arc<dyn Subchannel>],
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     for sc in subchannels {
-//         lb_policy.subchannel_update(sc.clone(), &SubchannelState::default(), tcc);
-//     }
-// }
-
-// fn move_subchannel_to_idle(
-//     lb_policy: &mut dyn LbPolicy,
-//     subchannel: Arc<dyn Subchannel>,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     lb_policy.subchannel_update(
-//         subchannel.clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::Idle,
-//             ..Default::default()
-//         },
-//         tcc,
-//     );
-// }
-
-// fn move_subchannel_to_connecting(
-//     lb_policy: &mut dyn LbPolicy,
-//     subchannel: Arc<dyn Subchannel>,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     lb_policy.subchannel_update(
-//         subchannel.clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::Connecting,
-//             ..Default::default()
-//         },
-//         tcc,
-//     );
-// }
-
-// fn move_subchannel_to_ready(
-//     lb_policy: &mut dyn LbPolicy,
-//     subchannel: Arc<dyn Subchannel>,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     lb_policy.subchannel_update(
-//         subchannel.clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::Ready,
-//             ..Default::default()
-//         },
-//         tcc,
-//     );
-// }
-
-// fn move_subchannel_to_transient_failure(
-//     lb_policy: &mut dyn LbPolicy,
-//     subchannel: Arc<dyn Subchannel>,
-//     err: &str,
-//     tcc: &mut dyn ChannelController,
-// ) {
-//     lb_policy.subchannel_update(
-//         subchannel.clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::TransientFailure,
-//             last_connection_error: Some(Arc::from(Box::from(err.to_owned()))),
-//         },
-//         tcc,
-//     );
-// }
-
-// // Verifies that a connection attempt is made to the given subchannel.
-// async fn verify_connection_attempt_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-//     subchannel: Arc<dyn Subchannel>,
-// ) {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::Connect(addr) => {
-//             assert!(addr == subchannel.address());
-//         }
-//         other => panic!("unexpected event {}", other),
-//     };
-// }
-
-// // Verifies that a call to schedule_work is made by the LB policy.
-// async fn verify_schedule_work_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::ScheduleWork => {}
-//         other => panic!("unexpected event {}", other),
-//     };
-// }
-
-// // Verifies that the channel moves to IDLE state.
-// //
-// // Returns the picker for tests to make more picks, if required.
-// async fn verify_idle_picker_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-// ) -> Arc<dyn Picker> {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::UpdatePicker(update) => {
-//             assert!(update.connectivity_state == ConnectivityState::Idle);
-//             update.picker.clone()
-//         }
-//         other => panic!("unexpected event {}", other),
-//     }
-// }
-
-// // Verifies that the channel moves to CONNECTING state with a queuing picker.
-// //
-// // Returns the picker for tests to make more picks, if required.
-// async fn verify_connecting_picker_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-// ) -> Arc<dyn Picker> {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::UpdatePicker(update) => {
-//             assert!(update.connectivity_state == ConnectivityState::Connecting);
-//             let req = test_utils::new_request();
-//             assert!(update.picker.pick(&req) == PickResult::Queue);
-//             update.picker.clone()
-//         }
-//         other => panic!("unexpected event {}", other),
-//     }
-// }
-
-// // Verifies that the channel moves to READY state with a picker that returns the
-// // given subchannel.
-// //
-// // Returns the picker for tests to make more picks, if required.
-// async fn verify_ready_picker_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-//     subchannel: Arc<dyn Subchannel>,
-// ) -> Arc<dyn Picker> {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::UpdatePicker(update) => {
-//             assert!(update.connectivity_state == ConnectivityState::Ready);
-//             let req = test_utils::new_request();
-//             match update.picker.pick(&req) {
-//                 PickResult::Pick(pick) => {
-//                     assert!(pick.subchannel == subchannel.clone());
-//                     update.picker.clone()
-//                 }
-//                 other => panic!("unexpected pick result {}", other),
-//             }
-//         }
-//         other => panic!("unexpected event {}", other),
-//     }
-// }
-
-// // Verifies that the channel moves to TRANSIENT_FAILURE state with a picker
-// // that returns an error with the given message. The error code should be
-// // UNAVAILABLE..
-// //
-// // Returns the picker for tests to make more picks, if required.
-// async fn verify_transient_failure_picker_from_policy(
-//     rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
-//     want_error: String,
-// ) -> Arc<dyn Picker> {
-//     let picker = match rx_events.recv().await.unwrap() {
-//         TestEvent::UpdatePicker(update) => {
-//             assert!(update.connectivity_state == ConnectivityState::TransientFailure);
-//             let req = test_utils::new_request();
-//             match update.picker.pick(&req) {
-//                 PickResult::Fail(status) => {
-//                     assert!(status.code() == tonic::Code::Unavailable);
-//                     assert!(status.message().contains(&want_error));
-//                     update.picker.clone()
-//                 }
-//                 other => panic!("unexpected pick result {}", other),
-//             }
-//         }
-//         other => panic!("unexpected event {}", other),
-//     };
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::RequestResolution => {}
-//         _ => panic!("no re-resolution requested after moving to transient_failure"),
-//     }
-//     picker
-// }
-
-// // Verifies that the channel moves to IDLE state.
-// async fn verify_channel_moves_to_idle(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::UpdatePicker(update) => {
-//             assert!(update.connectivity_state == ConnectivityState::Idle);
-//         }
-//         other => panic!("unexpected event {}", other),
-//     };
-// }
-
-// // Verifies that the LB policy requests re-resolution.
-// async fn verify_resolution_request(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
-//     match rx_events.recv().await.unwrap() {
-//         TestEvent::RequestResolution => {}
-//         other => panic!("unexpected event {}", other),
-//     };
-// }
-
-// const DEFAULT_TEST_SHORT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
-
-// async fn verify_no_activity_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
-//     tokio::select! {
-//         _ = tokio::time::sleep(DEFAULT_TEST_SHORT_TIMEOUT) => {}
-//         event = rx_events.recv() => {
-//             panic!("unexpected event {}", event.unwrap());
-//         }
-//     }
-// }
-
-// // Tests the scenario where the resolver returns an error before a valid update.
-// // The LB policy should move to TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_resolver_error_before_a_valid_update() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let resolver_error = String::from("resolver error");
-//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
-// }
-
-// // Tests the scenario where the resolver returns an error after a valid update
-// // and the LB policy has moved to READY. The LB policy should ignore the error
-// // and continue using the previously received update.
-// #[tokio::test]
-// async fn pickfirst_resolver_error_after_a_valid_update_in_ready() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-
-//     let picker = verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     let resolver_error = String::from("resolver error");
-//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
-//     verify_no_activity_from_policy(&mut rx_events).await;
-
-//     let req = test_utils::new_request();
-//     match picker.pick(&req) {
-//         PickResult::Pick(pick) => {
-//             assert!(pick.subchannel == subchannels[0].clone());
-//         }
-//         other => panic!("unexpected pick result {}", other),
-//     }
-// }
-
-// // Tests the scenario where the resolver returns an error after a valid update
-// // and the LB policy is still trying to connect. The LB policy should ignore the
-// // error and continue using the previously received update.
-// #[tokio::test]
-// async fn pickfirst_resolver_error_after_a_valid_update_in_connecting() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     let picker = verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     let resolver_error = String::from("resolver error");
-//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
-//     verify_no_activity_from_policy(&mut rx_events).await;
-
-//     let req = test_utils::new_request();
-//     match picker.pick(&req) {
-//         PickResult::Queue => {}
-//         other => panic!("unexpected pick result {}", other),
-//     }
-// }
-
-// // Tests the scenario where the resolver returns an error after a valid update
-// // and the LB policy has moved to TRANSIENT_FAILURE after attemting to connect
-// // to all addresses.  The LB policy should send a new picker that returns the
-// // error from the resolver.
-// #[tokio::test]
-// async fn pickfirst_resolver_error_after_a_valid_update_in_tf() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     let connection_error = String::from("test connection error");
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
-
-//     let resolver_error = String::from("resolver error");
-//     send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with no addresses
-// // (before sending any valid update). The LB policy should move to
-// // TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_zero_addresses_from_resolver_before_valid_update() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(0);
-//     let update = ResolverUpdate {
-//         endpoints: Ok(vec![endpoint]),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
-//     verify_transient_failure_picker_from_policy(
-//         &mut rx_events,
-//         "received empty address list from the name resolver".to_string(),
-//     )
-//     .await;
-// }
-
-// // Tests the scenario where the resolver returns an update with no endpoints
-// // (before sending any valid update). The LB policy should move to
-// // TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_zero_endpoints_from_resolver_before_valid_update() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let update = ResolverUpdate {
-//         endpoints: Ok(vec![]),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
-//     verify_transient_failure_picker_from_policy(
-//         &mut rx_events,
-//         "received empty address list from the name resolver".to_string(),
-//     )
-//     .await;
-// }
-
-// // Tests the scenario where the resolver returns an update with no endpoints
-// // after sending a valid update (and the LB policy has moved to READY). The LB
-// // policy should move to TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_zero_endpoints_from_resolver_after_valid_update() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     let update = ResolverUpdate {
-//         endpoints: Ok(vec![]),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
-//     verify_transient_failure_picker_from_policy(
-//         &mut rx_events,
-//         "received empty address list from the name resolver".to_string(),
-//     )
-//     .await;
-// }
-
-// // Tests the scenario where the resolver returns an update with one address. The
-// // LB policy should create a subchannel for that address, connect to it, and
-// // once the connection succeeds, move to READY state with a picker that returns
-// // that subchannel.
-// #[tokio::test]
-// async fn pickfirst_with_one_backend() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(1);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // address. The LB policy should create subchannels for all address, and attempt
-// // to connect to them in order, until a connection succeeds, at which point it
-// // should move to READY state with a picker that returns that subchannel.
-// #[tokio::test]
-// async fn pickfirst_with_multiple_backends_first_backend_is_ready() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // address. The LB policy should create subchannels for all address, and attempt
-// // to connect to them in order, until a connection succeeds, at which point it
-// // should move to READY state with a picker that returns that subchannel.
-// #[tokio::test]
-// async fn pickfirst_with_multiple_backends_first_backend_is_not_ready() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(3);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     let connection_error = String::from("test connection error");
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[2].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[2].clone(), tcc);
-//     move_subchannel_to_ready(lb_policy, subchannels[2].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[2].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // address, some of which are duplicates. The LB policy should dedup the
-// // addresses and create subchannels for them, and attempt to connect to them in
-// // order, until a connection succeeds, at which point it should move to READY
-// // state with a picker that returns that subchannel.
-// #[tokio::test]
-// async fn pickfirst_with_multiple_backends_duplicate_addresses() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = Endpoint {
-//         addresses: vec![
-//             Address {
-//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
-//                 ..Default::default()
-//             },
-//             Address {
-//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
-//                 ..Default::default()
-//             },
-//             Address {
-//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
-//                 ..Default::default()
-//             },
-//         ],
-//         ..Default::default()
-//     };
-//     let endpoint_with_duplicates_removed = Endpoint {
-//         addresses: vec![
-//             Address {
-//                 address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
-//                 ..Default::default()
-//             },
-//             Address {
-//                 address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
-//                 ..Default::default()
-//             },
-//         ],
-//         ..Default::default()
-//     };
-
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels = verify_subchannel_creation_from_policy(
-//         &mut rx_events,
-//         endpoint_with_duplicates_removed.addresses.clone(),
-//     )
-//     .await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     let connection_error = String::from("test connection error");
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and connections to all of them fail. The LB policy should move to
-// // TRANSIENT_FAILURE state with a failing picker. It should then attempt to connect
-// // to the addresses again, and when they fail again, it should send a new
-// // picker that returns the most recent error message.
-// #[tokio::test]
-// async fn pickfirst_sticky_transient_failure() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoint = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     let first_error = String::from("test connection error 1");
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &first_error, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &first_error, tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, first_error).await;
-
-//     // The subchannels need to complete their backoff before moving to IDLE, at
-//     // which point the LB policy should attempt to connect to them again.
-//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
-//     move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-
-//     let second_error = String::from("test connection error 2");
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &second_error, tcc);
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &second_error, tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, second_error).await;
-
-//     // The subchannels need to complete their backoff before moving to IDLE, at
-//     // which point the LB policy should attempt to connect to them again.
-//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
-//     move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Overrides the default shuffler function with a custom one that reverses the
-// // order of the endpoints.
-// fn test_reverse_shuffler() -> Box<EndpointShuffler> {
-//     Box::new(|endpoints: &mut [Endpoint]| {
-//         endpoints.reverse();
-//     })
-// }
-
-// // Resets the shuffler function to the default one after the test completes
-// struct ShufflerResetGuard {}
-// impl Drop for ShufflerResetGuard {
-//     fn drop(&mut self) {
-//         *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = thread_rng_shuffler();
-//     }
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // endpoints and LB config with shuffle addresses enabled. We override the
-// // shuffler functionality to reverse the order of the endpoints. The LB policy
-// // should create subchannels for all addresses, and attempt to connect to them
-// // in order, until a connection succeeds, at which point it should move to READY
-// // state with a picker that returns that subchannel.
-// #[tokio::test]
-// async fn pickfirst_with_multiple_backends_shuffle_addresses() {
-//     let _guard = ShufflerResetGuard {};
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-//     *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = test_reverse_shuffler();
-
-//     let endpoint1 = create_endpoint_with_one_address("1.1.1.1:1".to_string());
-//     let endpoint2 = create_endpoint_with_one_address("2.2.2.2:2".to_string());
-//     send_resolver_update_with_lb_config_to_policy(
-//         lb_policy,
-//         vec![endpoint1.clone(), endpoint2.clone()],
-//         tcc,
-//     );
-
-//     let subchannels = verify_subchannel_creation_from_policy(
-//         &mut rx_events,
-//         endpoint2
-//             .addresses
-//             .clone()
-//             .into_iter()
-//             .chain(endpoint1.addresses.iter().cloned())
-//             .collect(),
-//     )
-//     .await;
-
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The resolver then returns an update with a new address list that does
-// // not contain the address of the currently connected subchannel. The LB policy
-// // should create subchannels for the new addresses, and then realize that the
-// // currently connected subchannel is not in the new address list. It should then
-// // move to IDLE state and return a picker that queues RPCs. When an RPC is made,
-// // the LB policy should create subchannels for the addresses specified in the
-// // previous update and start connecting to them.
-// #[tokio::test]
-// async fn pickfirst_resolver_update_with_completely_new_address_list() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoints = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     let endpoints = create_endpoint_with_one_address("3.3.3.3:3".to_string());
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
-//     verify_resolution_request(&mut rx_events).await;
-//     let req = test_utils::new_request();
-//     assert!(picker.pick(&req) == PickResult::Queue);
-//     verify_schedule_work_from_policy(&mut rx_events).await;
-//     lb_policy.work(tcc);
-
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The resolver then returns an update with a new address list that
-// // contains the address of the currently connected subchannel. The LB policy
-// // should create subchannels for the new addresses, and then see that the
-// // currently connected subchannel is in the new address list. It should then
-// // send a new READY picker that returns the currently connected subchannel.
-// #[tokio::test]
-// async fn pickfirst_resolver_update_contains_currently_ready_subchannel() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoints = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     let mut endpoints = create_endpoint_with_n_addresses(4);
-//     endpoints.addresses.reverse();
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     lb_policy.subchannel_update(subchannels[0].clone(), &SubchannelState::default(), tcc);
-//     lb_policy.subchannel_update(subchannels[1].clone(), &SubchannelState::default(), tcc);
-//     lb_policy.subchannel_update(subchannels[2].clone(), &SubchannelState::default(), tcc);
-//     lb_policy.subchannel_update(
-//         subchannels[3].clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::Ready,
-//             ..Default::default()
-//         },
-//         tcc,
-//     );
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[3].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The resolver then returns an update with a an address list that is
-// // identical to the first update. The LB policy should create subchannels for
-// // the new addresses, and then see that the currently connected subchannel is in
-// // the new address list. It should then send a new READY picker that returns the
-// // currently connected subchannel.
-// #[tokio::test]
-// async fn pickfirst_resolver_update_contains_identical_address_list() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoints = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     lb_policy.subchannel_update(
-//         subchannels[0].clone(),
-//         &SubchannelState {
-//             connectivity_state: ConnectivityState::Ready,
-//             ..Default::default()
-//         },
-//         tcc,
-//     );
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The resolver then returns an update with a new address list that
-// // removes the address of the currently connected subchannel. The LB policy
-// // should create subchannels for the new addresses, and then see that the
-// // currently connected subchannel is not in the new address list. It should then
-// // move to IDLE state and return a picker that queues RPCs. When an RPC is made,
-// // the LB policy should create subchannels for the addresses specified in the
-// // previous update and start connecting to them. The test repeats this scenario
-// // multiple times, each time removing the first address from the address list,
-// // eventually ending up with an empty address list. The LB policy should move to
-// // TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_resolver_update_removes_connected_address() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let mut endpoints = create_endpoint_with_n_addresses(3);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     // Address list now contains two addresses.
-//     endpoints.addresses.remove(0);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
-//     verify_resolution_request(&mut rx_events).await;
-//     let req = test_utils::new_request();
-//     assert!(picker.pick(&req) == PickResult::Queue);
-//     verify_schedule_work_from_policy(&mut rx_events).await;
-//     lb_policy.work(tcc);
-
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     // Address list now contains one address.
-//     endpoints.addresses.remove(0);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
-//     verify_resolution_request(&mut rx_events).await;
-//     let req = test_utils::new_request();
-//     assert!(picker.pick(&req) == PickResult::Queue);
-//     verify_schedule_work_from_policy(&mut rx_events).await;
-//     lb_policy.work(tcc);
-
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     // Address list is now empty.
-//     endpoints.addresses.remove(0);
-//     let update = ResolverUpdate {
-//         endpoints: Ok(vec![endpoints]),
-//         ..Default::default()
-//     };
-//     assert!(lb_policy.resolver_update(update, None, tcc).is_err());
-//     verify_transient_failure_picker_from_policy(
-//         &mut rx_events,
-//         "received empty address list from the name resolver".to_string(),
-//     )
-//     .await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The connected subchannel then goes down and the LB policy moves to IDLE
-// // state with a picker that queues RPCs. When an RPC is made, the LB policy
-// // creates subchannels for the addresses specified in the previous update and
-// // starts connecting to them. The LB policy should then move to READY state with
-// // a picker that returns the second subchannel.
-// #[tokio::test]
-// async fn pickfirst_connected_subchannel_goes_down() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoints = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
-//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
-//     verify_resolution_request(&mut rx_events).await;
-//     let req = test_utils::new_request();
-//     assert!(picker.pick(&req) == PickResult::Queue);
-//     verify_schedule_work_from_policy(&mut rx_events).await;
-//     lb_policy.work(tcc);
-
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_transient_failure(
-//         lb_policy,
-//         subchannels[0].clone(),
-//         "connection error",
-//         tcc,
-//     );
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
-// }
-
-// // Tests the scenario where the resolver returns an update with multiple
-// // addresses and the LB policy successfully connects to first one and moves to
-// // READY. The connected subchannel then goes down and the LB policy moves to IDLE
-// // state with a picker that queues RPCs. When an RPC is made, the LB policy
-// // creates subchannels for the addresses specified in the previous update and
-// // starts connecting to them. All subchannels fail to connect and the LB policy
-// // moves to TRANSIENT_FAILURE state with a failing picker.
-// #[tokio::test]
-// async fn pickfirst_all_subchannels_goes_down() {
-//     let (mut rx_events, mut lb_policy, mut tcc) = setup();
-//     let lb_policy = lb_policy.as_mut();
-//     let tcc = tcc.as_mut();
-
-//     let endpoints = create_endpoint_with_n_addresses(2);
-//     send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
-//     verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
-
-//     move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
-//     let picker = verify_idle_picker_from_policy(&mut rx_events).await;
-//     verify_resolution_request(&mut rx_events).await;
-//     let req = test_utils::new_request();
-//     assert!(picker.pick(&req) == PickResult::Queue);
-//     verify_schedule_work_from_policy(&mut rx_events).await;
-//     lb_policy.work(tcc);
-
-//     let connection_error = String::from("test connection error 2");
-//     let subchannels =
-//         verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
-//     send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
-//     verify_connecting_picker_from_policy(&mut rx_events).await;
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
-//     verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
-//     move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
-//     move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
-//     verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
-// }
+use crate::client::{
+    load_balancing::{
+        pick_first::{
+            self, thread_rng_shuffler, EndpointShuffler, PickFirstConfig, SHUFFLE_ENDPOINTS_FN,
+        },
+        test_utils::{self, FakeChannel, TestEvent, TestWorkScheduler},
+        ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+        LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+        Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
+    },
+    name_resolution::{Address, Endpoint, ResolverUpdate},
+    transport::{Transport, GLOBAL_TRANSPORT_REGISTRY},
+    ConnectivityState,
+};
+use crate::service::{Message, Request, Response, Service};
+use core::panic;
+use rand::{rngs::StdRng, Rng, RngCore, SeedableRng};
+use serde_json::json;
+use std::{
+    ops::Add,
+    sync::{Arc, Mutex},
+};
+use tokio::{
+    sync::{mpsc, Notify},
+    task::AbortHandle,
+};
+use tonic::async_trait;
+
+#[test]
+fn pickfirst_builder_name() -> Result<(), String> {
+    pick_first::reg();
+
+    let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
+        Some(b) => b,
+        None => {
+            return Err(String::from("pick_first LB policy not registered"));
+        }
+    };
+    assert_eq!(builder.name(), "pick_first");
+    Ok(())
+}
+
+#[test]
+fn pickfirst_builder_parse_config_failure() -> Result<(), String> {
+    pick_first::reg();
+
+    let builder: Arc<dyn LbPolicyBuilder> = match GLOBAL_LB_REGISTRY.get_policy("pick_first") {
+        Some(b) => b,
+        None => {
+            return Err(String::from("pick_first LB policy not registered"));
+        }
+    };
+
+    // Success cases.
+    struct TestCase {
+        config: ParsedJsonLbConfig,
+        want_shuffle_addresses: Option<bool>,
+    }
+    let test_cases = vec![
+        TestCase {
+            config: ParsedJsonLbConfig(json!({})),
+            want_shuffle_addresses: None,
+        },
+        TestCase {
+            config: ParsedJsonLbConfig(json!({"shuffleAddressList": false})),
+            want_shuffle_addresses: Some(false),
+        },
+        TestCase {
+            config: ParsedJsonLbConfig(json!({"shuffleAddressList": true})),
+            want_shuffle_addresses: Some(true),
+        },
+        TestCase {
+            config: ParsedJsonLbConfig(json!({"shuffleAddressList": true, "unknownField": "foo"})),
+            want_shuffle_addresses: Some(true),
+        },
+    ];
+    for tc in test_cases {
+        let config = match builder.parse_config(&tc.config) {
+            Ok(c) => c,
+            Err(e) => {
+                let err = format!(
+                    "parse_config({:?}) failed when expected to succeed: {:?}",
+                    tc.config, e
+                )
+                .clone();
+                panic!("{}", err);
+            }
+        };
+        let config: LbConfig = match config {
+            Some(c) => c,
+            None => {
+                let err = format!(
+                    "parse_config({:?}) returned None when expected to succeed",
+                    tc.config
+                )
+                .clone();
+                panic!("{}", err);
+            }
+        };
+        let got_config: Arc<PickFirstConfig> = config.convert_to().unwrap();
+        assert!(got_config.shuffle_address_list == tc.want_shuffle_addresses);
+    }
+    Ok(())
+}
+
+// Sets up the test environment.
+//
+// Performs the following:
+// 1. Creates a work scheduler.
+// 2. Creates a fake channel that acts as a channel controller.
+// 3. Creates a pick_first LB policy.
+//
+// Returns the following:
+// 1. A receiver for events initiated by the LB policy (like creating a
+//    new subchannel, sending a new picker etc).
+// 2. The LB policy to send resolver and subchannel updates from the test.
+// 3. The channel to pass to the LB policy as part of the updates.
+fn setup() -> (
+    mpsc::UnboundedReceiver<TestEvent>,
+    Box<dyn LbPolicy>,
+    Box<dyn ChannelController>,
+) {
+    pick_first::reg();
+    let (tx_events, rx_events) = mpsc::unbounded_channel::<TestEvent>();
+    let work_scheduler = Arc::new(TestWorkScheduler {
+        tx_events: tx_events.clone(),
+    });
+    let tcc = Box::new(FakeChannel {
+        tx_events: tx_events.clone(),
+    });
+    let builder: Arc<dyn LbPolicyBuilder> = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
+    let lb_policy = builder.build(LbPolicyOptions { work_scheduler });
+
+    (rx_events, lb_policy, tcc)
+}
+
+fn create_endpoint_with_one_address(addr: String) -> Endpoint {
+    Endpoint {
+        addresses: vec![Address {
+            address: addr,
+            ..Default::default()
+        }],
+        ..Default::default()
+    }
+}
+
+// Creates a new endpoint with the specified number of addresses.
+fn create_endpoint_with_n_addresses(n: usize) -> Endpoint {
+    let mut addresses = Vec::new();
+    for i in 0..n {
+        addresses.push(Address {
+            address: format!("{}.{}.{}.{}:{}", i, i, i, i, i),
+            ..Default::default()
+        });
+    }
+    Endpoint {
+        addresses,
+        ..Default::default()
+    }
+}
+
+// Sends a resolver update to the LB policy with the specified endpoint.
+fn send_resolver_update_to_policy(
+    lb_policy: &mut dyn LbPolicy,
+    endpoints: Vec<Endpoint>,
+    tcc: &mut dyn ChannelController,
+) {
+    let update = ResolverUpdate {
+        endpoints: Ok(endpoints.clone()),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
+}
+
+// Sends a resolver update with LB config enabling address shuffling to the LB
+// policy with the specified endpoint.
+fn send_resolver_update_with_lb_config_to_policy(
+    lb_policy: &mut dyn LbPolicy,
+    endpoints: Vec<Endpoint>,
+    tcc: &mut dyn ChannelController,
+) {
+    let update = ResolverUpdate {
+        endpoints: Ok(endpoints.clone()),
+        ..Default::default()
+    };
+
+    let json_config = ParsedJsonLbConfig(json!({"shuffleAddressList": true}));
+    let builder = GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap();
+    let config = builder.parse_config(&json_config).unwrap();
+
+    assert!(lb_policy
+        .resolver_update(update, config.as_ref(), tcc)
+        .is_ok());
+}
+
+// Sends a resolver error to the LB policy with the specified error message.
+fn send_resolver_error_to_policy(
+    lb_policy: &mut dyn LbPolicy,
+    err: String,
+    tcc: &mut dyn ChannelController,
+) {
+    let update = ResolverUpdate {
+        endpoints: Err(err),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_ok());
+}
+
+// Verifies that the subchannels are created for the given addresses in the
+// given order. Returns the subchannels created.
+async fn verify_subchannel_creation_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    addresses: Vec<Address>,
+) -> Vec<Arc<dyn Subchannel>> {
+    let mut subchannels = Vec::new();
+    for address in addresses {
+        match rx_events.recv().await.unwrap() {
+            TestEvent::NewSubchannel(addr, sc) => {
+                assert!(addr == address.clone());
+                subchannels.push(sc);
+            }
+            other => panic!("unexpected event {}", other),
+        };
+    }
+    subchannels
+}
+
+// Sends initial subchannel updates to the LB policy for the given
+// subchannels, with their state set to IDLE.
+fn send_initial_subchannel_updates_to_policy(
+    lb_policy: &mut dyn LbPolicy,
+    subchannels: &[Arc<dyn Subchannel>],
+    tcc: &mut dyn ChannelController,
+) {
+    for sc in subchannels {
+        lb_policy.subchannel_update(sc.clone(), &SubchannelState::default(), tcc);
+    }
+}
+
+fn move_subchannel_to_idle(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Idle,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn move_subchannel_to_connecting(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    //calling lb_policy subchannel update
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Connecting,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn move_subchannel_to_ready(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Ready,
+            ..Default::default()
+        },
+        tcc,
+    );
+}
+
+fn move_subchannel_to_transient_failure(
+    lb_policy: &mut dyn LbPolicy,
+    subchannel: Arc<dyn Subchannel>,
+    err: &str,
+    tcc: &mut dyn ChannelController,
+) {
+    lb_policy.subchannel_update(
+        subchannel.clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::TransientFailure,
+            last_connection_error: Some(Arc::from(Box::from(err.to_owned()))),
+        },
+        tcc,
+    );
+}
+
+// Verifies that a connection attempt is made to the given subchannel.
+async fn verify_connection_attempt_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) {
+    let event = rx_events.recv().await.unwrap();
+    println!("  Subchannel: {}", event);
+    match event {
+    // match rx_events.recv().await.unwrap() {
+        TestEvent::Connect(addr) => {
+            assert!(addr == subchannel.address());
+        }
+        other => panic!("unexpected event {}", other),
+    };
+}
+
+// Verifies that a call to schedule_work is made by the LB policy.
+async fn verify_schedule_work_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::ScheduleWork => {}
+        other => panic!("unexpected event {}", other),
+    };
+}
+
+// Verifies that the channel moves to IDLE state.
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_idle_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+) -> Arc<dyn Picker> {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Idle);
+            update.picker.clone()
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the channel moves to CONNECTING state with a queuing picker.
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_connecting_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+) -> Arc<dyn Picker> {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Connecting);
+            let req = test_utils::new_request();
+            assert!(update.picker.pick(&req) == PickResult::Queue);
+            update.picker.clone()
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the channel moves to READY state with a picker that returns the
+// given subchannel.
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_ready_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    subchannel: Arc<dyn Subchannel>,
+) -> Arc<dyn Picker> {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Ready);
+            let req = test_utils::new_request();
+            match update.picker.pick(&req) {
+                PickResult::Pick(pick) => {
+                    assert!(pick.subchannel == subchannel.clone());
+                    update.picker.clone()
+                }
+                other => panic!("unexpected pick result {}", other),
+            }
+        }
+        other => panic!("unexpected event {}", other),
+    }
+}
+
+// Verifies that the channel moves to TRANSIENT_FAILURE state with a picker
+// that returns an error with the given message. The error code should be
+// UNAVAILABLE..
+//
+// Returns the picker for tests to make more picks, if required.
+async fn verify_transient_failure_picker_from_policy(
+    rx_events: &mut mpsc::UnboundedReceiver<TestEvent>,
+    want_error: String,
+) -> Arc<dyn Picker> {
+    let picker = match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::TransientFailure);
+            let req = test_utils::new_request();
+            match update.picker.pick(&req) {
+                PickResult::Fail(status) => {
+                    assert!(status.code() == tonic::Code::Unavailable);
+                    assert!(status.message().contains(&want_error));
+                    update.picker.clone()
+                }
+                other => panic!("unexpected pick result {}", other),
+            }
+        }
+        other => panic!("unexpected event {}", other),
+    };
+    match rx_events.recv().await.unwrap() {
+        TestEvent::RequestResolution => {}
+        _ => panic!("no re-resolution requested after moving to transient_failure"),
+    }
+    picker
+}
+
+// Verifies that the channel moves to IDLE state.
+async fn verify_channel_moves_to_idle(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::UpdatePicker(update) => {
+            assert!(update.connectivity_state == ConnectivityState::Idle);
+        }
+        other => panic!("unexpected event {}", other),
+    };
+}
+
+// Verifies that the LB policy requests re-resolution.
+async fn verify_resolution_request(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+    match rx_events.recv().await.unwrap() {
+        TestEvent::RequestResolution => {}
+        other => panic!("unexpected event {}", other),
+    };
+}
+
+const DEFAULT_TEST_SHORT_TIMEOUT: std::time::Duration = std::time::Duration::from_millis(100);
+
+async fn verify_no_activity_from_policy(rx_events: &mut mpsc::UnboundedReceiver<TestEvent>) {
+    tokio::select! {
+        _ = tokio::time::sleep(DEFAULT_TEST_SHORT_TIMEOUT) => {}
+        event = rx_events.recv() => {
+            panic!("unexpected event {}", event.unwrap());
+        }
+    }
+}
+
+// Tests the scenario where the resolver returns an error before a valid update.
+// The LB policy should move to TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_resolver_error_before_a_valid_update() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let resolver_error = String::from("resolver error");
+    send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+}
+
+// Tests the scenario where the resolver returns an error after a valid update
+// and the LB policy has moved to READY. The LB policy should ignore the error
+// and continue using the previously received update.
+#[tokio::test]
+async fn pickfirst_resolver_error_after_a_valid_update_in_ready() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+    let picker = verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    let resolver_error = String::from("resolver error");
+    send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+    verify_no_activity_from_policy(&mut rx_events).await;
+
+    let req = test_utils::new_request();
+    match picker.pick(&req) {
+        PickResult::Pick(pick) => {
+            assert!(pick.subchannel == subchannels[0].clone());
+        }
+        other => panic!("unexpected pick result {}", other),
+    }
+}
+
+// Tests the scenario where the resolver returns an error after a valid update
+// and the LB policy is still trying to connect. The LB policy should ignore the
+// error and continue using the previously received update.
+#[tokio::test]
+async fn pickfirst_resolver_error_after_a_valid_update_in_connecting() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    let picker = verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    let resolver_error = String::from("resolver error");
+    send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+    verify_no_activity_from_policy(&mut rx_events).await;
+
+    let req = test_utils::new_request();
+    match picker.pick(&req) {
+        PickResult::Queue => {}
+        other => panic!("unexpected pick result {}", other),
+    }
+}
+
+// Tests the scenario where the resolver returns an error after a valid update
+// and the LB policy has moved to TRANSIENT_FAILURE after attemting to connect
+// to all addresses.  The LB policy should send a new picker that returns the
+// error from the resolver.
+#[tokio::test]
+async fn pickfirst_resolver_error_after_a_valid_update_in_tf() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    let connection_error = String::from("test connection error");
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
+
+    let resolver_error = String::from("resolver error");
+    send_resolver_error_to_policy(lb_policy, resolver_error.clone(), tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, resolver_error).await;
+}
+
+// Tests the scenario where the resolver returns an update with no addresses
+// (before sending any valid update). The LB policy should move to
+// TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_zero_addresses_from_resolver_before_valid_update() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(0);
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoint]),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+    verify_transient_failure_picker_from_policy(
+        &mut rx_events,
+        "received empty address list from the name resolver".to_string(),
+    )
+    .await;
+}
+
+// Tests the scenario where the resolver returns an update with no endpoints
+// (before sending any valid update). The LB policy should move to
+// TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_zero_endpoints_from_resolver_before_valid_update() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![]),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+    verify_transient_failure_picker_from_policy(
+        &mut rx_events,
+        "received empty address list from the name resolver".to_string(),
+    )
+    .await;
+}
+
+// Tests the scenario where the resolver returns an update with no endpoints
+// after sending a valid update (and the LB policy has moved to READY). The LB
+// policy should move to TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_zero_endpoints_from_resolver_after_valid_update() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![]),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+    verify_transient_failure_picker_from_policy(
+        &mut rx_events,
+        "received empty address list from the name resolver".to_string(),
+    )
+    .await;
+}
+
+// Tests the scenario where the resolver returns an update with one address. The
+// LB policy should create a subchannel for that address, connect to it, and
+// once the connection succeeds, move to READY state with a picker that returns
+// that subchannel.
+#[tokio::test]
+async fn pickfirst_with_one_backend() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(1);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// address. The LB policy should create subchannels for all address, and attempt
+// to connect to them in order, until a connection succeeds, at which point it
+// should move to READY state with a picker that returns that subchannel.
+#[tokio::test]
+async fn pickfirst_with_multiple_backends_first_backend_is_ready() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// address. The LB policy should create subchannels for all address, and attempt
+// to connect to them in order, until a connection succeeds, at which point it
+// should move to READY state with a picker that returns that subchannel.
+#[tokio::test]
+async fn pickfirst_with_multiple_backends_first_backend_is_not_ready() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(3);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    let connection_error = String::from("test connection error");
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[2].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[2].clone(), tcc);
+    move_subchannel_to_ready(lb_policy, subchannels[2].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[2].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// address, some of which are duplicates. The LB policy should dedup the
+// addresses and create subchannels for them, and attempt to connect to them in
+// order, until a connection succeeds, at which point it should move to READY
+// state with a picker that returns that subchannel.
+#[tokio::test]
+async fn pickfirst_with_multiple_backends_duplicate_addresses() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = Endpoint {
+        addresses: vec![
+            Address {
+                address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+                ..Default::default()
+            },
+            Address {
+                address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+                ..Default::default()
+            },
+            Address {
+                address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+    let endpoint_with_duplicates_removed = Endpoint {
+        addresses: vec![
+            Address {
+                address: format!("{}.{}.{}.{}:{}", 0, 0, 0, 0, 0),
+                ..Default::default()
+            },
+            Address {
+                address: format!("{}.{}.{}.{}:{}", 1, 1, 1, 1, 1),
+                ..Default::default()
+            },
+        ],
+        ..Default::default()
+    };
+
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels = verify_subchannel_creation_from_policy(
+        &mut rx_events,
+        endpoint_with_duplicates_removed.addresses.clone(),
+    )
+    .await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    let connection_error = String::from("test connection error");
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and connections to all of them fail. The LB policy should move to
+// TRANSIENT_FAILURE state with a failing picker. It should then attempt to connect
+// to the addresses again, and when they fail again, it should send a new
+// picker that returns the most recent error message.
+#[tokio::test]
+async fn pickfirst_sticky_transient_failure() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoint = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoint.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoint.addresses.clone()).await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    let first_error = String::from("test connection error 1");
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &first_error, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &first_error, tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, first_error).await;
+
+    // The subchannels need to complete their backoff before moving to IDLE, at
+    // which point the LB policy should attempt to connect to them again.
+    move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+    move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+
+    let second_error = String::from("test connection error 2");
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &second_error, tcc);
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &second_error, tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, second_error).await;
+
+    // The subchannels need to complete their backoff before moving to IDLE, at
+    // which point the LB policy should attempt to connect to them again.
+    move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+    move_subchannel_to_idle(lb_policy, subchannels[1].clone(), tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Overrides the default shuffler function with a custom one that reverses the
+// order of the endpoints.
+fn test_reverse_shuffler() -> Box<EndpointShuffler> {
+    Box::new(|endpoints: &mut [Endpoint]| {
+        endpoints.reverse();
+    })
+}
+
+// Resets the shuffler function to the default one after the test completes
+struct ShufflerResetGuard {}
+impl Drop for ShufflerResetGuard {
+    fn drop(&mut self) {
+        *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = thread_rng_shuffler();
+    }
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// endpoints and LB config with shuffle addresses enabled. We override the
+// shuffler functionality to reverse the order of the endpoints. The LB policy
+// should create subchannels for all addresses, and attempt to connect to them
+// in order, until a connection succeeds, at which point it should move to READY
+// state with a picker that returns that subchannel.
+#[tokio::test]
+async fn pickfirst_with_multiple_backends_shuffle_addresses() {
+    let _guard = ShufflerResetGuard {};
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+    *SHUFFLE_ENDPOINTS_FN.lock().unwrap() = test_reverse_shuffler();
+
+    let endpoint1 = create_endpoint_with_one_address("1.1.1.1:1".to_string());
+    let endpoint2 = create_endpoint_with_one_address("2.2.2.2:2".to_string());
+    send_resolver_update_with_lb_config_to_policy(
+        lb_policy,
+        vec![endpoint1.clone(), endpoint2.clone()],
+        tcc,
+    );
+
+    let subchannels = verify_subchannel_creation_from_policy(
+        &mut rx_events,
+        endpoint2
+            .addresses
+            .clone()
+            .into_iter()
+            .chain(endpoint1.addresses.iter().cloned())
+            .collect(),
+    )
+    .await;
+
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The resolver then returns an update with a new address list that does
+// not contain the address of the currently connected subchannel. The LB policy
+// should create subchannels for the new addresses, and then realize that the
+// currently connected subchannel is not in the new address list. It should then
+// move to IDLE state and return a picker that queues RPCs. When an RPC is made,
+// the LB policy should create subchannels for the addresses specified in the
+// previous update and start connecting to them.
+#[tokio::test]
+async fn pickfirst_resolver_update_with_completely_new_address_list() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoints = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    let endpoints = create_endpoint_with_one_address("3.3.3.3:3".to_string());
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+    verify_resolution_request(&mut rx_events).await;
+    let req = test_utils::new_request();
+    assert!(picker.pick(&req) == PickResult::Queue);
+    verify_schedule_work_from_policy(&mut rx_events).await;
+    lb_policy.work(tcc);
+
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The resolver then returns an update with a new address list that
+// contains the address of the currently connected subchannel. The LB policy
+// should create subchannels for the new addresses, and then see that the
+// currently connected subchannel is in the new address list. It should then
+// send a new READY picker that returns the currently connected subchannel.
+#[tokio::test]
+async fn pickfirst_resolver_update_contains_currently_ready_subchannel() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoints = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    let mut endpoints = create_endpoint_with_n_addresses(4);
+    endpoints.addresses.reverse();
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    lb_policy.subchannel_update(subchannels[0].clone(), &SubchannelState::default(), tcc);
+    lb_policy.subchannel_update(subchannels[1].clone(), &SubchannelState::default(), tcc);
+    lb_policy.subchannel_update(subchannels[2].clone(), &SubchannelState::default(), tcc);
+    lb_policy.subchannel_update(
+        subchannels[3].clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Ready,
+            ..Default::default()
+        },
+        tcc,
+    );
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[3].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The resolver then returns an update with a an address list that is
+// identical to the first update. The LB policy should create subchannels for
+// the new addresses, and then see that the currently connected subchannel is in
+// the new address list. It should then send a new READY picker that returns the
+// currently connected subchannel.
+#[tokio::test]
+async fn pickfirst_resolver_update_contains_identical_address_list() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoints = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    lb_policy.subchannel_update(
+        subchannels[0].clone(),
+        &SubchannelState {
+            connectivity_state: ConnectivityState::Ready,
+            ..Default::default()
+        },
+        tcc,
+    );
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The resolver then returns an update with a new address list that
+// removes the address of the currently connected subchannel. The LB policy
+// should create subchannels for the new addresses, and then see that the
+// currently connected subchannel is not in the new address list. It should then
+// move to IDLE state and return a picker that queues RPCs. When an RPC is made,
+// the LB policy should create subchannels for the addresses specified in the
+// previous update and start connecting to them. The test repeats this scenario
+// multiple times, each time removing the first address from the address list,
+// eventually ending up with an empty address list. The LB policy should move to
+// TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_resolver_update_removes_connected_address() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let mut endpoints = create_endpoint_with_n_addresses(3);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    // Address list now contains two addresses.
+    endpoints.addresses.remove(0);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+    verify_resolution_request(&mut rx_events).await;
+    let req = test_utils::new_request();
+    assert!(picker.pick(&req) == PickResult::Queue);
+    verify_schedule_work_from_policy(&mut rx_events).await;
+    lb_policy.work(tcc);
+
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    // Address list now contains one address.
+    endpoints.addresses.remove(0);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+    verify_resolution_request(&mut rx_events).await;
+    let req = test_utils::new_request();
+    assert!(picker.pick(&req) == PickResult::Queue);
+    verify_schedule_work_from_policy(&mut rx_events).await;
+    lb_policy.work(tcc);
+
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    // Address list is now empty.
+    endpoints.addresses.remove(0);
+    let update = ResolverUpdate {
+        endpoints: Ok(vec![endpoints]),
+        ..Default::default()
+    };
+    assert!(lb_policy.resolver_update(update, None, tcc).is_err());
+    verify_transient_failure_picker_from_policy(
+        &mut rx_events,
+        "received empty address list from the name resolver".to_string(),
+    )
+    .await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The connected subchannel then goes down and the LB policy moves to IDLE
+// state with a picker that queues RPCs. When an RPC is made, the LB policy
+// creates subchannels for the addresses specified in the previous update and
+// starts connecting to them. The LB policy should then move to READY state with
+// a picker that returns the second subchannel.
+#[tokio::test]
+async fn pickfirst_connected_subchannel_goes_down() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoints = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+    let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+    verify_resolution_request(&mut rx_events).await;
+    let req = test_utils::new_request();
+    assert!(picker.pick(&req) == PickResult::Queue);
+    verify_schedule_work_from_policy(&mut rx_events).await;
+    lb_policy.work(tcc);
+
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_transient_failure(
+        lb_policy,
+        subchannels[0].clone(),
+        "connection error",
+        tcc,
+    );
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    move_subchannel_to_ready(lb_policy, subchannels[1].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[1].clone()).await;
+}
+
+// Tests the scenario where the resolver returns an update with multiple
+// addresses and the LB policy successfully connects to first one and moves to
+// READY. The connected subchannel then goes down and the LB policy moves to IDLE
+// state with a picker that queues RPCs. When an RPC is made, the LB policy
+// creates subchannels for the addresses specified in the previous update and
+// starts connecting to them. All subchannels fail to connect and the LB policy
+// moves to TRANSIENT_FAILURE state with a failing picker.
+#[tokio::test]
+async fn pickfirst_all_subchannels_goes_down() {
+    let (mut rx_events, mut lb_policy, mut tcc) = setup();
+    let lb_policy = lb_policy.as_mut();
+    let tcc = tcc.as_mut();
+
+    let endpoints = create_endpoint_with_n_addresses(2);
+    send_resolver_update_to_policy(lb_policy, vec![endpoints.clone()], tcc);
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_ready(lb_policy, subchannels[0].clone(), tcc);
+    verify_ready_picker_from_policy(&mut rx_events, subchannels[0].clone()).await;
+
+    move_subchannel_to_idle(lb_policy, subchannels[0].clone(), tcc);
+    let picker = verify_idle_picker_from_policy(&mut rx_events).await;
+    verify_resolution_request(&mut rx_events).await;
+    let req = test_utils::new_request();
+    assert!(picker.pick(&req) == PickResult::Queue);
+    verify_schedule_work_from_policy(&mut rx_events).await;
+    lb_policy.work(tcc);
+
+    let connection_error = String::from("test connection error 2");
+    let subchannels =
+        verify_subchannel_creation_from_policy(&mut rx_events, endpoints.addresses.clone()).await;
+    send_initial_subchannel_updates_to_policy(lb_policy, &subchannels, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[0].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[0].clone(), tcc);
+    verify_connecting_picker_from_policy(&mut rx_events).await;
+    move_subchannel_to_transient_failure(lb_policy, subchannels[0].clone(), &connection_error, tcc);
+    verify_connection_attempt_from_policy(&mut rx_events, subchannels[1].clone()).await;
+    move_subchannel_to_connecting(lb_policy, subchannels[1].clone(), tcc);
+    move_subchannel_to_transient_failure(lb_policy, subchannels[1].clone(), &connection_error, tcc);
+    verify_transient_failure_picker_from_policy(&mut rx_events, connection_error).await;
+}

--- a/grpc/src/client/load_balancing/registry.rs
+++ b/grpc/src/client/load_balancing/registry.rs
@@ -10,6 +10,9 @@ use super::LbPolicyBuilder;
 /// A registry to store and retrieve LB policies.  LB policies are indexed by
 /// their names.
 pub struct LbPolicyRegistry {
+    //Anyone that wants a reference to the Arc and mutate the data needs
+    //to go throguh Mutex first and lock it to access and mutate the data
+    //Arc allows for multiple things to own the data
     m: Arc<Mutex<HashMap<String, Arc<dyn LbPolicyBuilder>>>>,
 }
 
@@ -29,6 +32,10 @@ impl LbPolicyRegistry {
     pub fn get_policy(&self, name: &str) -> Option<Arc<dyn LbPolicyBuilder>> {
         self.m.lock().unwrap().get(name).cloned()
     }
+
+    // pub fn get_box_policy(&self, name: &str) -> Option<Box<dyn LbPolicyBuilder>> {
+    //     self.m.unwrap().get(name).cloned()
+    // }
 }
 
 impl Default for LbPolicyRegistry {

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -1,0 +1,344 @@
+use crate::client::{
+    load_balancing::{
+        pick_first::{
+            self, 
+        },
+        child_manager::{
+            self, 
+        },
+        ChannelController, ExternalSubchannel, Failing, LbConfig, LbPolicy, LbPolicyBuilder,
+        LbPolicyOptions, LbState, ParsedJsonLbConfig, PickResult, Picker, QueuingPicker,
+        Subchannel, SubchannelState, WorkScheduler, GLOBAL_LB_REGISTRY,
+    },
+    name_resolution::{Address, Endpoint, ResolverUpdate},
+    transport::{Transport, GLOBAL_TRANSPORT_REGISTRY},
+    ConnectivityState,
+};
+
+use std::{collections::HashMap, collections::HashSet, error::Error, hash::Hash, mem, sync::Arc};
+
+use crate::service::{Message, Request, Response, Service};
+use core::panic;
+use serde_json::json;
+use std::{
+    ops::Add,
+    sync::{ Mutex},
+};
+use tokio::{
+    sync::{mpsc, Notify},
+    task::AbortHandle,
+};
+
+use crate::client::load_balancing::child_manager::ChildManager;
+
+use once_cell::sync::Lazy;
+use rand::{self, rngs::StdRng, seq::SliceRandom, thread_rng, Rng, RngCore, SeedableRng};
+use serde::{Deserialize, Serialize};
+use tokio::time::sleep;
+use tonic::{async_trait, metadata::MetadataMap};
+use crate::client::load_balancing::child_manager::ChildUpdate;
+
+use crate::client::load_balancing::child_manager::ResolverUpdateSharder;
+use crate::client::load_balancing::Pick;
+
+#[cfg(test)]
+mod test;
+
+pub static POLICY_NAME: &str = "round_robin";
+
+struct RoundRobinBuilder {}
+
+impl LbPolicyBuilder for RoundRobinBuilder {
+    fn build(&self, options: LbPolicyOptions) -> Box<dyn LbPolicy> {
+        let resolver_update_sharder = ResolverUpdateSharderStruct {builder:GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap()};
+        let lb_policy = Box::new(ChildManager::<Endpoint>::new(options.work_scheduler, Box::new(resolver_update_sharder)));
+        Box::new(RoundRobinPolicy {
+            child_manager: lb_policy,
+            addresses: vec![],
+            last_resolver_error: None,
+            last_connection_error: None,
+            connectivity_state: ConnectivityState::Connecting,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        POLICY_NAME
+    }
+
+}
+
+/** 
+struct for round_robin
+*/
+//wrap pick first in a LB policy that calls ExitIdle whenever a subchannel disconnects
+struct RoundRobinPolicy {
+
+    //builder or built?
+    child_manager: Box<ChildManager<Endpoint>>,
+ 
+    addresses: Vec<Address>,                 // Most recent addresses from the name resolver.
+    last_resolver_error: Option<String>,     // Most recent error from the name resolver.
+    last_connection_error: Option<Arc<dyn Error + Send + Sync>>, // Most recent error from any subchannel.
+    connectivity_state: ConnectivityState, // Overall connectivity state of the channel.
+    // num_transient_failures: usize, // Number of transient failures after the end of the first pass.
+}
+
+impl RoundRobinPolicy {
+    fn address_list_from_endpoints(&self, endpoints: &[Endpoint]) -> Vec<Address> {
+        // Flatten the endpoints list by concatenating the ordered list of
+        // addresses for each of the endpoints.
+        let mut addresses: Vec<Address> = endpoints
+            .iter()
+            .flat_map(|ep| ep.addresses.clone())
+            .collect();
+
+        // Remove duplicates.
+        let mut uniques = HashSet::new();
+        addresses.retain(|e| uniques.insert(e.clone()));
+
+        // TODO(easwars): Implement address family interleaving as part of
+        // the dualstack implementation.
+
+        addresses
+    }
+
+    fn move_to_transient_failure(&mut self, channel_controller: &mut dyn ChannelController) {
+        self.connectivity_state = ConnectivityState::TransientFailure;
+        let err = format!(
+            "last seen resolver error: {:?}, last seen connection error: {:?}",
+            self.last_resolver_error, self.last_connection_error,
+        );
+        channel_controller.update_picker(LbState {
+            connectivity_state: ConnectivityState::TransientFailure,
+            picker: Arc::new(Failing { error: err }),
+        });
+        channel_controller.request_resolution();
+    }
+}
+pub fn reg() {
+    super::GLOBAL_LB_REGISTRY.add_builder(RoundRobinBuilder {});
+}
+
+//have to instantiate pickfirst builder first
+struct WrapperPickFirstPolicy {pick_first: Box<dyn LbPolicy>}
+
+struct WrappedPickFirstBuilder {}
+
+pub static WRAPPED_PICKFIRST_NAME: &str = "wrapped_pick_First";
+
+impl LbPolicyBuilder for WrappedPickFirstBuilder{
+    fn build(&self, options: LbPolicyOptions) -> Box<dyn LbPolicy> {
+        Box::new(WrapperPickFirstPolicy {
+            pick_first: GLOBAL_LB_REGISTRY.get_policy("pick_first").unwrap().build(LbPolicyOptions { work_scheduler: options.work_scheduler}),
+        })
+        
+    }
+
+    fn name(&self) -> &'static str {
+        WRAPPED_PICKFIRST_NAME
+    }
+}
+ 
+
+impl LbPolicy for WrapperPickFirstPolicy {
+
+    fn resolver_update(
+        &mut self,
+        update: ResolverUpdate,
+        config: Option<&LbConfig>,
+        channel_controller: &mut dyn ChannelController,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+        
+        let result = self.pick_first.resolver_update(update, config, &mut wrapped_channel_controller);
+        if let Some(state) = wrapped_channel_controller.picker_update.clone() {
+            if state.connectivity_state == ConnectivityState::Idle {
+                    self.exit_idle(&mut wrapped_channel_controller);
+            }
+               
+            }
+        result
+        }
+        
+
+    
+    fn subchannel_update(
+        &mut self,
+        subchannel: Arc<dyn Subchannel>,
+        state: &SubchannelState,
+        channel_controller: &mut dyn ChannelController,
+    ) {
+        
+        let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+        self.pick_first.subchannel_update(subchannel, state, &mut wrapped_channel_controller);
+        if let Some(state) = wrapped_channel_controller.picker_update.clone() {
+            if state.connectivity_state == ConnectivityState::Idle {
+                self.exit_idle(&mut wrapped_channel_controller);
+            }
+               
+        }
+    }
+
+    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+        let mut wrapped_channel_controller = WrappedController::new(channel_controller);
+    
+        self.pick_first.work(&mut wrapped_channel_controller);
+    }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        self.pick_first.exit_idle(channel_controller);
+    }
+}
+
+struct WrappedController<'a> {
+    channel_controller: &'a mut dyn ChannelController,
+    // created_subchannels: Vec<Arc<dyn Subchannel>>,
+
+    //have this be a bool and set true when set to idle
+    picker_update: Option<LbState>,
+}
+
+impl<'a> WrappedController<'a> {
+    fn new(channel_controller: &'a mut dyn ChannelController) -> Self {
+        Self {
+            channel_controller,
+            // created_subchannels: vec![],
+            picker_update: None,
+        }
+    }
+}
+
+impl ChannelController for WrappedController<'_> {
+    //call into the real channel controller
+    fn new_subchannel(&mut self, address: &Address) -> Arc<dyn Subchannel> {
+        let subchannel = self.channel_controller.new_subchannel(address);
+        subchannel
+    }
+
+    fn update_picker(&mut self, update: LbState) {
+        self.channel_controller.update_picker(update);
+        // self.picker_update = Some(update);
+    }
+
+    fn request_resolution(&mut self) {
+        // self.channel_controller.request_resolution(update);
+        self.channel_controller.request_resolution();
+    }
+}
+
+//build pick first builder in round robin builder and get policy (if not seen, panic)
+struct ResolverUpdateSharderStruct {builder: Arc<dyn LbPolicyBuilder>}
+
+//need implementation for sharder trait and pass it to child manager new in build
+//and store it in round robin policy. need another struct to implement this trait.
+//need to pass an instance of that trait when creating child manager. then store that child manager
+//in round robin policy. 
+impl ResolverUpdateSharder<Endpoint> for ResolverUpdateSharderStruct {
+    fn shard_update(
+        &self,
+        resolver_update: ResolverUpdate,
+        //T is an endpoint and ChildUpdate struct is going to have a builder
+        //pass in pickfirst into that builder
+        //child update field in the ChildUpdate struct 
+        //would contain any attributes in the input resolverupdate
+    ) -> Result<HashMap<Endpoint, ChildUpdate>, Box<dyn Error + Send + Sync>> {
+        let mut hashmap = HashMap::new();
+        let builder = self.builder.clone();
+        for endpoint in resolver_update.endpoints.clone().unwrap().iter() {
+            let child_update = ChildUpdate{
+                child_policy_builder: self.builder.clone(),
+                //create new resolver update with particular endpoint
+                child_update: ResolverUpdate {attributes: resolver_update.attributes.clone(), endpoints: Ok(vec![endpoint.clone()]), service_config: resolver_update.service_config.clone(), resolution_note: resolver_update.resolution_note.clone()},
+            };
+            hashmap.insert(endpoint.clone(), child_update);
+        }
+        Ok(hashmap)
+    }
+}
+
+
+
+
+
+
+
+impl LbPolicy for RoundRobinPolicy {
+    fn resolver_update(
+        &mut self,
+        update: ResolverUpdate,
+        config: Option<&LbConfig>,
+        channel_controller: &mut dyn ChannelController,
+    ) -> Result<(), Box<dyn Error + Send + Sync>> {
+        let cloned_update = update.clone();
+        match update.endpoints {
+            Ok( endpoints) => {
+                //create child manager here?
+
+                println!(
+                    "received update from resolver with endpoints: {:?}",
+                    endpoints
+                );
+                let new_addresses: Vec<Address> = self.address_list_from_endpoints(&endpoints);
+                let result = self.child_manager.resolver_update(cloned_update, config, channel_controller);
+                self.addresses = new_addresses;
+
+               
+            }
+            //think about whether to handle here or in child manager
+            Err(error) => {
+                println!("received error from resolver: {}", error);
+                // self.last_resolver_error = Some(error);
+
+                // // Enter or stay in TF, if there is no good previous update from
+                // // the resolver, or if already in TF. Regardless, send a new
+                // // failing picker with the updated error information.
+                if self.addresses.is_empty()
+                    || self.connectivity_state == ConnectivityState::TransientFailure
+                {
+                    self.move_to_transient_failure(channel_controller);
+                }
+
+                // Continue using the previous good update, if one exists.
+            }
+        }
+        Ok(())
+    }
+
+    fn subchannel_update(
+        &mut self,
+        subchannel: Arc<dyn Subchannel>,
+        state: &SubchannelState,
+        channel_controller: &mut dyn ChannelController,
+    ) {
+        println!("received update for {}: {}", subchannel, state);
+
+        // Handle the update for this subchannel, provided it's included in the
+        // subchannel list (if the list exists).
+
+        self.child_manager.subchannel_update(subchannel, state, channel_controller);
+    }
+
+    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+        // Build a new subchannel list with the most recent addresses received
+        // from the name resolver. This will start connecting from the first
+        // address in the list.
+
+        self.child_manager.work(channel_controller);
+
+        // self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
+    }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        // Build a new subchannel list with the most recent addresses received
+        // from the name resolver. This will start connecting from the first
+        // address in the list.
+
+        self.child_manager.exit_idle(channel_controller);
+
+        // self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
+    }
+}
+
+
+
+

--- a/grpc/src/client/load_balancing/round_robin.rs
+++ b/grpc/src/client/load_balancing/round_robin.rs
@@ -132,7 +132,7 @@ impl RoundRobinPolicy {
 
 }
 
-struct RoundRobinPicker {
+pub struct RoundRobinPicker {
     pickers: Vec<Arc<dyn Picker>>,
     next: AtomicUsize,
 }
@@ -194,7 +194,7 @@ impl LbPolicy for WrapperPickFirstPolicy {
         println!("calling resolver update on wrapped pick first policy");
         let mut wrapped_channel_controller = WrappedController::new(channel_controller);
         
-        let result = self.pick_first.resolver_update(update, config, &mut wrapped_channel_controller);
+        let result = self.pick_first.resolver_update(update, None, &mut wrapped_channel_controller);
         
         if let Some(state) = wrapped_channel_controller.picker_update.clone() {
             println!("state connectivity state is {}", state.connectivity_state);

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -164,6 +164,7 @@ impl LbPolicy for MockBalancerOne {
     ) {
         if let Some(ref mut scl) = self.subchannel_list {
             scl.update_subchannel_data(&subchannel, state);
+            println!("updating ready picker for mock balancer 2");
             // Optionally, send a picker update to simulate state change
             channel_controller.update_picker(LbState {
                 connectivity_state: state.connectivity_state,
@@ -207,7 +208,8 @@ impl LbPolicy for MockBalancerTwo {
         channel_controller: &mut dyn ChannelController,
     ) {
         if let Some(ref mut scl) = self.subchannel_list {
-            scl.update_subchannel_data(&subchannel, state);
+            // scl.update_subchannel_data(&subchannel, state);
+            println!("updating ready picker for mock balancer 2");
             // Optionally, send a picker update to simulate state change
             channel_controller.update_picker(LbState {
                 connectivity_state: state.connectivity_state,

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -89,6 +89,7 @@ impl Display for TestEvent {
     }
 }
 
+//perhaps add stub balancer
 pub(crate) struct FakeChannel {
     pub tx_events: mpsc::UnboundedSender<TestEvent>,
 }

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -7,10 +7,7 @@ use crate::client::{
 };
 use crate::service::{Message, Request, Response, Service};
 use std::{
-    fmt::Display,
-    hash::{Hash, Hasher},
-    ops::Add,
-    sync::Arc,
+    fmt::Display, hash::{Hash, Hasher}, ops::Add, ptr, sync::Arc
 };
 use tokio::{
     sync::{mpsc, Notify},
@@ -58,13 +55,13 @@ impl ForwardingSubchannel for TestSubchannel {
 
 impl Hash for TestSubchannel {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
-        self.address.hash(state);
+        ptr::hash(self, state); 
     }
 }
 
 impl PartialEq for TestSubchannel {
     fn eq(&self, other: &Self) -> bool {
-        self.address == other.address
+        ptr::eq(self, other)
     }
 }
 impl Eq for TestSubchannel {}

--- a/grpc/src/client/load_balancing/test_utils.rs
+++ b/grpc/src/client/load_balancing/test_utils.rs
@@ -1,18 +1,19 @@
 use crate::client::{
     load_balancing::{
-        ChannelController, ExternalSubchannel, ForwardingSubchannel, LbState, Subchannel,
-        WorkScheduler,
-    },
-    name_resolution::Address,
+        ChannelController, ExternalSubchannel, ForwardingSubchannel, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState, ParsedJsonLbConfig, Pick, PickResult, Picker, Subchannel, SubchannelState, WorkScheduler
+    }, name_resolution::Address, service_config::LbConfig, ConnectivityState
 };
 use crate::service::{Message, Request, Response, Service};
 use std::{
-    fmt::Display, hash::{Hash, Hasher}, ops::Add, ptr, sync::Arc
+    collections::HashMap, error::Error, fmt::Display, hash::{Hash, Hasher}, ops::Add, ptr, sync::Arc
 };
+use futures_util::future::ok;
+use serde::{Deserialize, Serialize};
 use tokio::{
     sync::{mpsc, Notify},
     task::AbortHandle,
 };
+use tonic::metadata::MetadataMap;
 
 pub(crate) struct EmptyMessage {}
 impl Message for EmptyMessage {}
@@ -124,4 +125,333 @@ impl WorkScheduler for TestWorkScheduler {
     fn schedule_work(&self) {
         self.tx_events.send(TestEvent::ScheduleWork).unwrap();
     }
+}
+
+pub struct MockBalancerOne {
+    connectivity_state: ConnectivityState,
+    subchannel_list: Option<SubchannelList>,
+}
+
+pub struct MockBalancerTwo {
+    connectivity_state: ConnectivityState,
+    subchannel_list: Option<SubchannelList>,
+}
+
+impl LbPolicy for MockBalancerOne {
+    fn resolver_update(
+        &mut self,
+        update: crate::client::name_resolution::ResolverUpdate,
+        config: Option<&crate::client::service_config::LbConfig>,
+        channel_controller: &mut dyn ChannelController,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Ok(ref endpoints) = update.endpoints {
+            let addresses: Vec<_> = endpoints.iter().flat_map(|ep| ep.addresses.clone()).collect();
+            let scl = SubchannelList::new(&addresses, channel_controller);
+            self.subchannel_list = Some(scl);
+        }
+        channel_controller.update_picker(LbState {
+            connectivity_state: self.connectivity_state,
+            picker: Arc::new(MockPickerOne),
+        });
+        Ok(())
+    }
+
+    fn subchannel_update(
+        &mut self,
+        subchannel: Arc<dyn Subchannel>,
+        state: &super::SubchannelState,
+        channel_controller: &mut dyn ChannelController,
+    ) {
+        if let Some(ref mut scl) = self.subchannel_list {
+            scl.update_subchannel_data(&subchannel, state);
+            // Optionally, send a picker update to simulate state change
+            channel_controller.update_picker(LbState {
+                connectivity_state: state.connectivity_state,
+                picker: Arc::new(MockPickerOne), // or MockPickerTwo
+            });
+        }
+    }
+
+    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+        todo!()
+    }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        todo!()
+    }
+}
+
+impl LbPolicy for MockBalancerTwo {
+    fn resolver_update(
+        &mut self,
+        update: crate::client::name_resolution::ResolverUpdate,
+        config: Option<&crate::client::service_config::LbConfig>,
+        channel_controller: &mut dyn ChannelController,
+    ) -> Result<(), Box<dyn std::error::Error + Send + Sync>> {
+        if let Ok(ref endpoints) = update.endpoints {
+            let addresses: Vec<_> = endpoints.iter().flat_map(|ep| ep.addresses.clone()).collect();
+            let scl = SubchannelList::new(&addresses, channel_controller);
+            self.subchannel_list = Some(scl);
+        }
+        channel_controller.update_picker(LbState {
+            connectivity_state: self.connectivity_state,
+            picker: Arc::new(MockPickerTwo),
+        });
+        Ok(())
+    }
+
+    fn subchannel_update(
+        &mut self,
+        subchannel: Arc<dyn Subchannel>,
+        state: &super::SubchannelState,
+        channel_controller: &mut dyn ChannelController,
+    ) {
+        if let Some(ref mut scl) = self.subchannel_list {
+            scl.update_subchannel_data(&subchannel, state);
+            // Optionally, send a picker update to simulate state change
+            channel_controller.update_picker(LbState {
+                connectivity_state: state.connectivity_state,
+                picker: Arc::new(MockPickerTwo), // or MockPickerTwo
+            });
+        }
+    }
+
+    fn work(&mut self, channel_controller: &mut dyn ChannelController) {
+        todo!()
+    }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        todo!()
+    }
+}
+pub static POLICY_NAME: &str = "mock_policy_one";
+pub static MOCK_POLICY_TWO: &str = "mock_policy_two";
+
+struct MockPolicyOneBuilder {}
+struct MockPolicyTwoBuilder {}
+
+
+impl LbPolicyBuilder for MockPolicyOneBuilder {
+    fn build(&self, options: LbPolicyOptions) -> Box<dyn LbPolicy> {
+        Box::new(MockBalancerOne {
+            // work_scheduler: options.work_scheduler,
+            subchannel_list: None,
+            // selected_subchannel: None,
+            // addresses: vec![],
+            // last_resolver_error: None,
+            // last_connection_error: None,
+            connectivity_state: ConnectivityState::Connecting,
+            // sent_connecting_state: false,
+            // num_transient_failures: 0,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        POLICY_NAME
+    }
+
+    fn parse_config(
+        &self,
+        config: &ParsedJsonLbConfig,
+    ) -> Result<Option<LbConfig>, Box<dyn Error + Send + Sync>> {
+        let cfg: MockConfig = match config.convert_to() {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(format!("failed to parse JSON config: {}", e).into());
+            }
+        };
+        Ok(Some(LbConfig::new(cfg)))
+    }
+}
+
+#[derive(Serialize, Deserialize, Debug)]
+#[serde(rename_all = "camelCase")]
+pub(super) struct MockConfig {
+    shuffle_address_list: Option<bool>,
+}
+
+impl LbPolicyBuilder for MockPolicyTwoBuilder {
+    fn build(&self, options: LbPolicyOptions) -> Box<dyn LbPolicy> {
+        Box::new(MockBalancerTwo {
+            // work_scheduler: options.work_scheduler,
+            subchannel_list: None,
+            // selected_subchannel: None,
+            // addresses: vec![],
+            // last_resolver_error: None,
+            // last_connection_error: None,
+            connectivity_state: ConnectivityState::Connecting,
+            // sent_connecting_state: false,
+            // num_transient_failures: 0,
+        })
+    }
+
+    fn name(&self) -> &'static str {
+        MOCK_POLICY_TWO
+    }
+
+    fn parse_config(
+        &self,
+        config: &ParsedJsonLbConfig,
+    ) -> Result<Option<LbConfig>, Box<dyn Error + Send + Sync>> {
+        let cfg: MockConfig = match config.convert_to() {
+            Ok(c) => c,
+            Err(e) => {
+                return Err(format!("failed to parse JSON config: {}", e).into());
+            }
+        };
+        Ok(Some(LbConfig::new(cfg)))
+    }
+
+   
+}
+
+#[derive(Clone)]
+struct SubchannelData {
+    state: Option<SubchannelState>,
+    seen_transient_failure: bool,
+}
+
+impl SubchannelData {
+    fn new() -> SubchannelData {
+        SubchannelData {
+            state: None,
+            seen_transient_failure: false,
+        }
+    }
+}
+
+struct SubchannelList {
+    subchannels: HashMap<Arc<dyn Subchannel>, SubchannelData>,
+    ordered_subchannels: Vec<Arc<dyn Subchannel>>,
+    current_idx: usize,
+    num_initial_notifications_seen: usize,
+}
+
+impl SubchannelList {
+    fn new(addresses: &Vec<Address>, channel_controller: &mut dyn ChannelController) -> Self {
+        let mut scl = SubchannelList {
+            subchannels: HashMap::new(),
+            ordered_subchannels: Vec::new(),
+            current_idx: 0,
+            num_initial_notifications_seen: 0,
+        };
+        for address in addresses {
+            let sc = channel_controller.new_subchannel(address);
+            scl.ordered_subchannels.push(sc.clone());
+            scl.subchannels.insert(sc, SubchannelData::new());
+        }
+
+        println!("created new subchannel list with {} subchannels", scl.len());
+        scl
+    }
+
+    fn len(&self) -> usize {
+        self.ordered_subchannels.len()
+    }
+
+    fn subchannel_data(&self, sc: &Arc<dyn Subchannel>) -> Option<SubchannelData> {
+        self.subchannels.get(sc).cloned()
+    }
+
+    fn contains(&self, sc: &Arc<dyn Subchannel>) -> bool {
+        self.subchannels.contains_key(sc)
+    }
+
+    // Updates internal state of the subchannel with the new state. Callers must
+    // ensure that this method is called only for subchannels in the list.
+    //
+    // Returns old state corresponding to the subchannel, if one exists.
+    fn update_subchannel_data(
+        &mut self,
+        sc: &Arc<dyn Subchannel>,
+        state: &SubchannelState,
+    ) -> Option<SubchannelState> {
+        let sc_data = self.subchannels.get_mut(sc).unwrap();
+
+        // Increment the counter when seeing the first update.
+        if sc_data.state.is_none() {
+            self.num_initial_notifications_seen += 1;
+        }
+
+        let old_state = sc_data.state.clone();
+        sc_data.state = Some(state.clone());
+        match state.connectivity_state {
+            ConnectivityState::Ready => sc_data.seen_transient_failure = false,
+            ConnectivityState::TransientFailure => sc_data.seen_transient_failure = true,
+            _ => {}
+        }
+
+        old_state
+    }
+
+
+    // Initiates a connection attempt to the next subchannel in the list that is
+    // IDLE. Returns false if there are no more subchannels in the list.
+    fn connect_to_next_subchannel(
+        &mut self,
+        channel_controller: &mut dyn ChannelController,
+    ) -> bool {
+        // Special case for the first connection attempt, as current_idx is set
+        // to 0 when the subchannel list is created.
+        if self.current_idx != 0 {
+            self.current_idx += 1;
+        }
+
+        for idx in self.current_idx..self.ordered_subchannels.len() {
+            // Grab the next subchannel and its data.
+            let sc = &self.ordered_subchannels[idx];
+            let sc_data = self.subchannels.get(sc).unwrap();
+
+            match &sc_data.state {
+                Some(state) => {
+                    if state.connectivity_state == ConnectivityState::Connecting
+                        || state.connectivity_state == ConnectivityState::TransientFailure
+                    {
+                        self.current_idx += 1;
+                        continue;
+                    } else if state.connectivity_state == ConnectivityState::Idle {
+                        sc.connect();
+                        return true;
+                    }
+                }
+                None => {
+                    debug_assert!(
+                        false,
+                        "No state available when asked to connect to subchannel: {}",
+                        sc,
+                    );
+                }
+            }
+        }
+        false
+    }
+
+}
+
+pub struct MockPickerOne;
+pub struct MockPickerTwo;
+
+impl Picker for MockPickerOne {
+    fn pick(&self, _req: &Request) -> PickResult {
+        PickResult::Pick(Pick {
+            subchannel: Arc::new(TestSubchannel::new(Address { address: "one".to_string(), ..Default::default() }, mpsc::unbounded_channel().0)),
+            on_complete: None,
+            metadata: MetadataMap::new(),
+        })
+    }
+}
+
+impl Picker for MockPickerTwo {
+    fn pick(&self, _req: &Request) -> PickResult {
+        PickResult::Pick(Pick {
+            subchannel: Arc::new(TestSubchannel::new(Address { address: "two".to_string(), ..Default::default() }, mpsc::unbounded_channel().0)),
+            on_complete: None,
+            metadata: MetadataMap::new(),
+        })
+    }
+}
+
+pub fn reg() {
+    super::GLOBAL_LB_REGISTRY.add_builder(MockPolicyOneBuilder {});
+    super::GLOBAL_LB_REGISTRY.add_builder(MockPolicyTwoBuilder {});
 }

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -303,6 +303,19 @@ impl Hash for Address {
     }
 }
 
+impl fmt::Display for Endpoint {
+    fn fmt(&self, f: &mut fmt::Formatter<'_>) -> fmt::Result {
+        // Print all addresses, separated by commas
+        let addresses = self
+            .addresses
+            .iter()
+            .map(|addr| format!("{}", addr))
+            .collect::<Vec<_>>()
+            .join(", ");
+        write!(f, "Endpoint {{ addresses: [{}], attributes: {:?} }}", addresses, self.attributes)
+    }
+}
+
 impl Display for Address {
     fn fmt(&self, f: &mut Formatter<'_>) -> fmt::Result {
         write!(f, "{}:{}", self.network_type, self.address)

--- a/grpc/src/client/name_resolution/mod.rs
+++ b/grpc/src/client/name_resolution/mod.rs
@@ -25,6 +25,8 @@ use core::fmt;
 
 use super::service_config::{self, ServiceConfig};
 use crate::{attributes::Attributes, rt};
+
+use super::load_balancing::child_manager::ChildIdentifier;
 use std::{
     error::Error,
     fmt::{Display, Formatter},
@@ -249,6 +251,10 @@ pub struct Endpoint {
     /// Attributes contains arbitrary data about this endpoint intended for
     /// consumption by the LB policy.
     pub attributes: Attributes,
+}
+
+impl ChildIdentifier for Endpoint {
+
 }
 
 #[non_exhaustive]

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -24,6 +24,8 @@ pub struct ServiceConfig;
 
 /// A convenience wrapper for an LB policy's configuration object.
 #[derive(Debug)]
+#[derive(Clone)]
+
 pub struct LbConfig {
     config: Arc<dyn Any + Send + Sync>,
 }
@@ -40,6 +42,8 @@ impl LbConfig {
     pub fn convert_to<T: 'static + Send + Sync>(
         &self,
     ) -> Result<Arc<T>, Box<dyn Error + Send + Sync>> {
+        println!("TypeId in LbConfig: {:?}", self.config.type_id());
+        
         match self.config.clone().downcast::<T>() {
             Ok(c) => Ok(c),
             Err(e) => Err("failed to downcast to config type".into()),

--- a/grpc/src/client/service_config.rs
+++ b/grpc/src/client/service_config.rs
@@ -49,4 +49,6 @@ impl LbConfig {
             Err(e) => Err("failed to downcast to config type".into()),
         }
     }
+
+   
 }

--- a/routeguide/Cargo.toml
+++ b/routeguide/Cargo.toml
@@ -1,0 +1,10 @@
+[package]
+name = "routeguide"
+version = "0.1.0"
+edition = "2024"
+rust-version.workspace = true
+
+[dependencies]
+
+[lints]
+workspace = true

--- a/routeguide/src/main.rs
+++ b/routeguide/src/main.rs
@@ -1,0 +1,3 @@
+fn main() {
+    println!("Hello, world!");
+}


### PR DESCRIPTION
Add Graceful Switch first draft

Main concerns:

- Use child manager instead of maintaining own hashmap?

- Wrap pending + current policy in option instead of each field (this is probably better but I was running into ownership issue)

@easwars @dfawley @arjan-bal
