### PR TITLE
Add exit idle

### DIFF
--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -258,6 +258,17 @@ impl<T: ChildIdentifier> LbPolicy for ChildManager<T> {
             self.resolve_child_controller(channel_controller, child_idx);
         }
     }
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
+        let child_idxes = mem::take(&mut *self.pending_work.lock().unwrap());
+        for child_idx in child_idxes {
+            let mut channel_controller = WrappedController::new(channel_controller);
+            self.children[child_idx]
+                .policy
+                .exit_idle(&mut channel_controller);
+            self.resolve_child_controller(channel_controller, child_idx);
+        }
+    }
 }
 
 struct WrappedController<'a> {

--- a/grpc/src/client/load_balancing/mod.rs
+++ b/grpc/src/client/load_balancing/mod.rs
@@ -147,6 +147,8 @@ pub trait LbPolicy: Send {
     /// Called by the channel in response to a call from the LB policy to the
     /// WorkScheduler's request_work method.
     fn work(&mut self, channel_controller: &mut dyn ChannelController);
+
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController);
 }
 
 /// Controls channel behaviors.

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -222,6 +222,25 @@ impl LbPolicy for PickFirstPolicy {
         // address in the list.
         self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
     }
+
+    fn exit_idle(& mut self, channel_controller: &mut dyn ChannelController) {
+        println!("child calls exit_idle");
+        if self.connectivity_state == ConnectivityState::Idle {
+            let prev_list = &self.subchannel_list;
+            self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
+            self.move_to_connecting(channel_controller);
+            // if let Some(subchannel_list) = self.subchannel_list.as_mut() {
+            // Initiate connection attempt to the first subchannel in the list
+            if let Some(subchannel_list) = self.subchannel_list.as_mut() {
+                subchannel_list.connect_after_idle();
+            }
+            // self.subcconnect_to_all_subchannels(channel_controller);
+            // if let Some(subchannel_list) = self.subchannel_list.as_mut() {
+            //     println!("connecting to all subchannels");
+            //     let _ = subchannel_list.connect_to_next_subchannel(channel_controller);
+            // }
+        }
+    }
 }
 
 fn shuffle_endpoints(endpoints: &mut [Endpoint]) {
@@ -591,6 +610,12 @@ impl SubchannelList {
             if data.state.as_ref().unwrap().connectivity_state == ConnectivityState::Idle {
                 sc.connect();
             }
+        }
+    }
+
+    fn connect_after_idle(&mut self) {
+        for sc in &self.ordered_subchannels {
+            sc.connect();
         }
     }
 }

--- a/grpc/src/client/load_balancing/pick_first.rs
+++ b/grpc/src/client/load_balancing/pick_first.rs
@@ -10,9 +10,9 @@ use std::{
 use crate::{
     client::{
         load_balancing::{
-            ChannelController, Failing, LbPolicy, LbPolicyBuilder, LbPolicyOptions, LbState,
-            ParsedJsonLbConfig, Pick, PickResult, Picker, QueuingPicker, Subchannel,
-            ExternalSubchannel, SubchannelState, WorkScheduler,
+            ChannelController, ExternalSubchannel, Failing, LbPolicy, LbPolicyBuilder,
+            LbPolicyOptions, LbState, ParsedJsonLbConfig, Pick, PickResult, Picker, QueuingPicker,
+            Subchannel, SubchannelState, WorkScheduler,
         },
         name_resolution::{Address, Endpoint, ResolverUpdate},
         service_config::LbConfig,
@@ -223,22 +223,13 @@ impl LbPolicy for PickFirstPolicy {
         self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
     }
 
-    fn exit_idle(& mut self, channel_controller: &mut dyn ChannelController) {
-        println!("child calls exit_idle");
+    fn exit_idle(&mut self, channel_controller: &mut dyn ChannelController) {
         if self.connectivity_state == ConnectivityState::Idle {
-            let prev_list = &self.subchannel_list;
             self.subchannel_list = Some(SubchannelList::new(&self.addresses, channel_controller));
             self.move_to_connecting(channel_controller);
-            // if let Some(subchannel_list) = self.subchannel_list.as_mut() {
-            // Initiate connection attempt to the first subchannel in the list
             if let Some(subchannel_list) = self.subchannel_list.as_mut() {
                 subchannel_list.connect_after_idle();
             }
-            // self.subcconnect_to_all_subchannels(channel_controller);
-            // if let Some(subchannel_list) = self.subchannel_list.as_mut() {
-            //     println!("connecting to all subchannels");
-            //     let _ = subchannel_list.connect_to_next_subchannel(channel_controller);
-            // }
         }
     }
 }


### PR DESCRIPTION
Add exit idle logic in child manager, mod, and pick first

@dfawley @easwars After the pick first child exits idle, it creates a new subchannel list with no states following [this](https://github.com/grpc/grpc/blob/c0ab052093137476a6d47a1226273959ed891deb/doc/client_channel_specification.md#pick_first). This throws an error when I use connect_to_next or connect_all_subchannels because the subchannels don't have data/states yet. I wrote a new function connect_after_idle that connects regardless of subchannel state but this doesn't feel right unless I update the state of each subchannel in the new subchannel list. I looked at Go and it seemed like no new subchannel list is created. Which would be better? I can also ask the gRPC space on Chat.
