### PR TITLE
Add blanket implementation for child identifier

### DIFF
--- a/grpc/src/client/load_balancing/child_manager.rs
+++ b/grpc/src/client/load_balancing/child_manager.rs
@@ -44,6 +44,7 @@ pub struct ChildManager<T> {
 }
 
 pub trait ChildIdentifier: PartialEq + Hash + Eq + Send + Sync + 'static {}
+impl<T: PartialEq + Hash + Eq + Send + Sync + 'static> ChildIdentifier for T {}
 
 struct Child<T> {
     identifier: T,


### PR DESCRIPTION
Blanket implement ChildIdentifier for T

This works for Endpoint but looking into alternatives

@easwars @dfawley 